### PR TITLE
fix the kindling-collector-config.yml caused by "stat ~/.kube/config: no such file or directory"

### DIFF
--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -73,7 +73,7 @@ analyzers:
 processors:
   k8smetadataprocessor:
     kube_auth_type: kubeConfig
-    kube_config_dir: ~/.kube/config
+    kube_config_dir: root/.kube/config
     grace_delete_period: 60
   aggregateprocessor:
     # Aggregation duration window size. The unit is second.

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -73,7 +73,7 @@ analyzers:
 processors:
   k8smetadataprocessor:
     kube_auth_type: kubeConfig
-    kube_config_dir: root/.kube/config
+    kube_config_dir: /root/.kube/config
     grace_delete_period: 60
   aggregateprocessor:
     # Aggregation duration window size. The unit is second.

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -73,7 +73,7 @@ analyzers:
 processors:
   k8smetadataprocessor:
     kube_auth_type: serviceAccount
-    kube_config_dir: ~/.kube/config
+    kube_config_dir: /root/.kube/config
     grace_delete_period: 60
   aggregateprocessor:
     # Aggregation duration window size. The unit is second.


### PR DESCRIPTION
Signed-off-by: yaofighting <siyao@zju.edu.cn>

<!--- Provide a general summary of your changes in the Title above -->
fix the collector config and make it running normally on the Linux environment
## Description
<!--- Describe your changes in detail -->
in the file /root/kindling/collector/docker/kindling-collector-config.yml, we can see a bug about that we may not boot the collector normally in the Linux environment due to the "kube_config_dir" is "~" instead of "root", so in this PR, I fix it.
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
https://github.com/Kindling-project/kindling/issues/224
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
it fix the compatibility of collector
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
just compile and build the collector container with the doc's step.
