### PR TITLE
Search for k8s metadata using src_ip when no containerid found

### DIFF
--- a/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
+++ b/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
@@ -1,6 +1,8 @@
 package k8sprocessor
 
 import (
+	"strconv"
+
 	"github.com/Kindling-project/kindling/collector/component"
 	"github.com/Kindling-project/kindling/collector/consumer"
 	"github.com/Kindling-project/kindling/collector/consumer/processor"
@@ -9,7 +11,6 @@ import (
 	"github.com/Kindling-project/kindling/collector/model/constlabels"
 	"github.com/Kindling-project/kindling/collector/model/constnames"
 	"go.uber.org/zap"
-	"strconv"
 )
 
 const (
@@ -85,15 +86,36 @@ func (p *K8sMetadataProcessor) processTcpMetric(dataGroup *model.DataGroup) {
 func (p *K8sMetadataProcessor) addK8sMetaDataForClientLabel(labelMap *model.AttributeMap) {
 	// add metadata for src
 	containerId := labelMap.GetStringValue(constlabels.ContainerId)
-	labelMap.UpdateAddStringValue(constlabels.SrcContainerId, containerId)
-	resInfo, ok := p.metadata.GetByContainerId(containerId)
-	if ok {
-		addContainerMetaInfoLabelSRC(labelMap, resInfo)
+	if containerId != "" {
+		labelMap.UpdateAddStringValue(constlabels.SrcContainerId, containerId)
+		resInfo, ok := p.metadata.GetByContainerId(containerId)
+		if ok {
+			addContainerMetaInfoLabelSRC(labelMap, resInfo)
+		} else {
+			labelMap.UpdateAddStringValue(constlabels.SrcNodeIp, p.localNodeIp)
+			labelMap.UpdateAddStringValue(constlabels.SrcNode, p.localNodeName)
+			labelMap.UpdateAddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
+		}
 	} else {
-		labelMap.UpdateAddStringValue(constlabels.SrcNodeIp, p.localNodeIp)
-		labelMap.UpdateAddStringValue(constlabels.SrcNode, p.localNodeName)
-		labelMap.UpdateAddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
+		srcIp := labelMap.GetStringValue(constlabels.SrcIp)
+		if srcIp == loopbackIp {
+			labelMap.UpdateAddStringValue(constlabels.SrcNodeIp, p.localNodeIp)
+			labelMap.UpdateAddStringValue(constlabels.SrcNode, p.localNodeName)
+		}
+		podInfo, ok := p.metadata.GetPodByIp(srcIp)
+		if ok {
+			addPodMetaInfoLabelSRC(labelMap, podInfo)
+		} else {
+			if nodeName, ok := p.metadata.GetNodeNameByIp(srcIp); ok {
+				labelMap.UpdateAddStringValue(constlabels.SrcNodeIp, srcIp)
+				labelMap.UpdateAddStringValue(constlabels.SrcNode, nodeName)
+				labelMap.UpdateAddStringValue(constlabels.SrcNamespace, constlabels.InternalClusterNamespace)
+			} else {
+				labelMap.UpdateAddStringValue(constlabels.SrcNamespace, constlabels.ExternalClusterNamespace)
+			}
+		}
 	}
+
 	// add metadata for dst
 	dstIp := labelMap.GetStringValue(constlabels.DstIp)
 	if dstIp == loopbackIp {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Search for k8s metadata using `src_ip` when no `container_id` is found.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We have found that the event from the client-side doesn't contain the container id in a very small possibility, in which case we take the src_ip as the key to find its k8s metadata.