### PR TITLE
Add the field PID to the TCP connect metrics

### DIFF
--- a/collector/analyzer/tcpconnectanalyzer/analyzer.go
+++ b/collector/analyzer/tcpconnectanalyzer/analyzer.go
@@ -197,6 +197,7 @@ func (a *TcpConnectAnalyzer) generateLabels(connectStats *internal.ConnectionSta
 	labels := model.NewAttributeMap()
 	// The connect events always come from the client-side
 	labels.AddBoolValue(constlabels.IsServer, false)
+	labels.AddIntValue(constlabels.Pid, int64(connectStats.Pid))
 	labels.AddStringValue(constlabels.ContainerId, connectStats.ContainerId)
 	labels.AddIntValue(constlabels.Errno, int64(connectStats.Code))
 	if connectStats.StateMachine.GetCurrentState() == internal.Success {

--- a/collector/analyzer/tcpconnectanalyzer/internal/connection_stats.go
+++ b/collector/analyzer/tcpconnectanalyzer/internal/connection_stats.go
@@ -27,7 +27,7 @@ const (
 )
 
 type ConnectionStats struct {
-	pid              uint32
+	Pid              uint32
 	ContainerId      string
 	ConnKey          ConnKey
 	StateMachine     *StateMachine

--- a/collector/analyzer/tcpconnectanalyzer/internal/state_machine_test.go
+++ b/collector/analyzer/tcpconnectanalyzer/internal/state_machine_test.go
@@ -12,7 +12,7 @@ func TestCallback(t *testing.T) {
 	}
 	statesResource := createStatesResource()
 	connStats := &ConnectionStats{
-		pid:              0,
+		Pid:              0,
 		ConnKey:          connKey,
 		InitialTimestamp: 0,
 		EndTimestamp:     0,

--- a/collector/consumer/processor/aggregateprocessor/processor.go
+++ b/collector/consumer/processor/aggregateprocessor/processor.go
@@ -205,6 +205,7 @@ func newTcpLabelSelectors() *aggregator.LabelSelectors {
 
 func newTcpConnectLabelSelectors() *aggregator.LabelSelectors {
 	return aggregator.NewLabelSelectors(
+		aggregator.LabelSelector{Name: constlabels.Pid, VType: aggregator.IntType},
 		aggregator.LabelSelector{Name: constlabels.SrcNode, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.SrcNodeIp, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.SrcNamespace, VType: aggregator.StringType},

--- a/docs/prometheus_metrics.md
+++ b/docs/prometheus_metrics.md
@@ -207,6 +207,7 @@ We made some rules for considering whether a request is abnormal. For the abnorm
 ### Labels List
 | **Label Name** | **Example** | **Notes** |
 | --- | --- | --- |
+| `pid` | 1024 | The client's process ID |
 | `src_node` | slave-node1 | Which node the source pod is on |
 | `src_namespace` | default | Namespace of the source pod |
 | `src_workload_kind` | deployment | Workload kind of the source pod |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add the field `PID` to the TCP connect metrics. Note it is 0 when no syscall events come.

![image](https://user-images.githubusercontent.com/46807570/171546137-5d65b209-c3f4-46e3-a41b-ba6362eecb7b.png)
