### PR TITLE
Add DNAT labels to tcp connect metrics

### DIFF
--- a/collector/consumer/processor/aggregateprocessor/processor.go
+++ b/collector/consumer/processor/aggregateprocessor/processor.go
@@ -198,6 +198,8 @@ func newTcpLabelSelectors() *aggregator.LabelSelectors {
 		aggregator.LabelSelector{Name: constlabels.DstService, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.DstIp, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.DstPort, VType: aggregator.IntType},
+		aggregator.LabelSelector{Name: constlabels.DnatIp, VType: aggregator.StringType},
+		aggregator.LabelSelector{Name: constlabels.DnatPort, VType: aggregator.IntType},
 		aggregator.LabelSelector{Name: constlabels.DstContainerId, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.DstContainer, VType: aggregator.StringType},
 	)

--- a/collector/consumer/processor/aggregateprocessor/processor.go
+++ b/collector/consumer/processor/aggregateprocessor/processor.go
@@ -227,6 +227,8 @@ func newTcpConnectLabelSelectors() *aggregator.LabelSelectors {
 		aggregator.LabelSelector{Name: constlabels.DstService, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.DstIp, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.DstPort, VType: aggregator.IntType},
+		aggregator.LabelSelector{Name: constlabels.DnatIp, VType: aggregator.StringType},
+		aggregator.LabelSelector{Name: constlabels.DnatPort, VType: aggregator.IntType},
 		aggregator.LabelSelector{Name: constlabels.DstContainerId, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.DstContainer, VType: aggregator.StringType},
 		aggregator.LabelSelector{Name: constlabels.Errno, VType: aggregator.IntType},

--- a/docs/prometheus_metrics.md
+++ b/docs/prometheus_metrics.md
@@ -226,6 +226,8 @@ We made some rules for considering whether a request is abnormal. For the abnorm
 | `dst_container` | business-container | The name of the destination container |
 | `dst_ip` | 10.1.11.24 | Pod's IP by default. If the destination is not a pod in Kubernetes, this is the IP address of an external entity |
 | `dst_port` | 80 | The listening port of the destination container, if applicable |
+| `dnat_ip` | 192.168.12.3 | The IP address of the destination after DNAT if applicable |
+| `dnat_port` | 80 | The listening port of the destination container after DNAT if applicable |
 | `success` | true | Whether the TCP connection is successfully established |
 | `errno` | 0 | The error number of the TCP connection. 0 if no error. Note it could also be 0 even if there is an error. |
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add DNAT labels to tcp connect metrics

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need DNAT labels in the final metrics to display the pod's IP:Port.
