### PR TITLE
Set container name empty when multiple containers don't specify ports

### DIFF
--- a/collector/metadata/kubernetes/pod_delete.go
+++ b/collector/metadata/kubernetes/pod_delete.go
@@ -60,6 +60,10 @@ func deletePod(pod *corev1.Pod) {
 	}
 
 	for _, container := range pod.Spec.Containers {
+		if len(container.Ports) == 0 {
+			MetaDataCache.DeleteContainerByIpPort(pod.Status.PodIP, 0)
+			continue
+		}
 		for _, port := range container.Ports {
 			// Assume that PodIP:Port can't be reused in a few seconds
 			MetaDataCache.DeleteContainerByIpPort(pod.Status.PodIP, uint32(port.ContainerPort))

--- a/collector/metadata/kubernetes/pod_watch.go
+++ b/collector/metadata/kubernetes/pod_watch.go
@@ -213,7 +213,14 @@ func onAdd(obj interface{}) {
 				HostPortMap: make(map[int32]int32),
 				RefPodInfo:  kpi,
 			}
+			// Not specifying a port DOES NOT prevent that port from being exposed.
+			// So Ports could be empty, if so we only record its IP address.
 			if len(tmpContainer.Ports) == 0 {
+				// If there are more than one container that doesn't specify a port,
+				// we would rather get an empty name empty than get an incorrect name.
+				if len(pod.Spec.Containers) > 0 {
+					containerInfo.Name = ""
+				}
 				// When there are many pods in one pod and only some of them have ports,
 				// the containers at the back will overwrite the one at the front here.
 				MetaDataCache.AddContainerByIpPort(pod.Status.PodIP, 0, containerInfo)

--- a/collector/metadata/kubernetes/pod_watch.go
+++ b/collector/metadata/kubernetes/pod_watch.go
@@ -216,13 +216,13 @@ func onAdd(obj interface{}) {
 			// Not specifying a port DOES NOT prevent that port from being exposed.
 			// So Ports could be empty, if so we only record its IP address.
 			if len(tmpContainer.Ports) == 0 {
-				// If there are more than one container that doesn't specify a port,
-				// we would rather get an empty name empty than get an incorrect name.
+				// If there is more than one container that doesn't specify a port,
+				// we would rather get an empty name than get an incorrect one.
 				if len(pod.Spec.Containers) > 0 {
 					containerInfo.Name = ""
 				}
-				// When there are many pods in one pod and only some of them have ports,
-				// the containers at the back will overwrite the one at the front here.
+				// When there are many containers in one pod and only part of them have ports,
+				// the containers at the back will overwrite the ones at the front here.
 				MetaDataCache.AddContainerByIpPort(pod.Status.PodIP, 0, containerInfo)
 				continue
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Set container name empty when multiple containers don't specify ports.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When there are multiple containers specified in one pod but they don't specify ports listened, we added them to the map using the combination of pod IP and port 0 as the key. This would cause us to find an incorrect container name using pod IP and the listening port. Since there is no method to find the exact container we want, I think we should set the container name to empty in case it makes the final result confusing.

Note that if there is only one container in the pod and it doesn't specify its port, we remain its name since no other containers confuse us.