### PR TITLE
Block in the application instead of the udsreceiver after running 

### DIFF
--- a/collector/application/application.go
+++ b/collector/application/application.go
@@ -3,6 +3,7 @@ package application
 import (
 	"flag"
 	"fmt"
+	"sync"
 
 	"github.com/Kindling-project/kindling/collector/analyzer"
 	"github.com/Kindling-project/kindling/collector/analyzer/loganalyzer"
@@ -27,6 +28,7 @@ type Application struct {
 	telemetry         *component.TelemetryManager
 	receiver          receiver.Receiver
 	analyzerManager   *analyzer.Manager
+	shutdownWG        sync.WaitGroup
 }
 
 func New() (*Application, error) {
@@ -58,14 +60,18 @@ func (a *Application) Run() error {
 	}
 	// Wait until the receiver shutdowns
 	err = a.receiver.Start()
+	a.shutdownWG.Add(1)
 	if err != nil {
 		return fmt.Errorf("failed to start application: %v", err)
 	}
+	a.shutdownWG.Wait()
 	return nil
 }
 
 func (a *Application) Shutdown() error {
-	return multierr.Combine(a.receiver.Shutdown(), a.analyzerManager.ShutdownAll(a.telemetry.Telemetry.Logger))
+	err := a.receiver.Shutdown()
+	a.shutdownWG.Done()
+	return multierr.Combine(err, a.analyzerManager.ShutdownAll(a.telemetry.Telemetry.Logger))
 }
 
 func initFlags() error {

--- a/collector/main.go
+++ b/collector/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/Kindling-project/kindling/collector/application"
 	"github.com/Kindling-project/kindling/collector/version"
-	"log"
 )
 
 func main() {
@@ -20,4 +24,16 @@ func main() {
 		log.Fatalf("Failed to run application: %v", err)
 	}
 
+	// Register signal handler
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	// Block until a signal is received.
+	select {
+	case sig := <-sigCh:
+		log.Printf("Received signal [%v], and will exit", sig)
+		if err = app.Shutdown(); err != nil {
+			log.Printf("Error happened when shutting down: %v", err)
+			os.Exit(1)
+		}
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Block the program in the main function instead of the udsreceiver after running. This is necessary if we want to replace the current receiver, otherwise, the application will exit immediately.
2. Fix the typo `shutdwonState` to `shutdownState` in the udsreceiver.
3. Set receiving high water mark of the pull socket instead of sending.