### PR TITLE
Export the trace of MySQL request when it contains an error

### DIFF
--- a/collector/analyzer/network/protocol/mysql/mysql_response.go
+++ b/collector/analyzer/network/protocol/mysql/mysql_response.go
@@ -53,6 +53,10 @@ func parseMysqlErr() protocol.ParsePkgFn {
 
 		message.AddIntAttribute(constlabels.SqlErrCode, int64(errorCode))
 		message.AddUtf8StringAttribute(constlabels.SqlErrMsg, errorMessage)
+		if errorCode != 0 {
+			message.AddBoolAttribute(constlabels.IsError, true)
+			message.AddIntAttribute(constlabels.ErrorType, int64(constlabels.ProtocolError))
+		}
 		return true, true
 	}
 }

--- a/docs/prometheus_metrics.md
+++ b/docs/prometheus_metrics.md
@@ -52,7 +52,7 @@ Service metrics are generated from the server-side events, which are used to sho
 | **Label** | **Example** | **Notes** |
 | --- | --- | --- |
 | `request_content` | select employee | SQL of MySQL. SQL has been truncated to avoid high-cardinality. The format is ['operation' 'space' 'table']. |
-| `response_content` |  | Empty temporarily. |
+| `response_content` | 1064 | Error code of MySQL. Only applicable when the response is in error type. |
 
 - When protocol is `kafka`:
   
@@ -121,6 +121,7 @@ These two terms are composed of two parts.
 
 - **HTTP**: 'Status Code' of HTTP response. 
 - **DNS**: rcode of DNS response.
+- **MySQL**: Error code of the error response.
 - **DUBBO**: 'Error Code' of Dubbo request.
 - **others**: empty temporarily
 

--- a/docs/prometheus_metrics.md
+++ b/docs/prometheus_metrics.md
@@ -52,7 +52,7 @@ Service metrics are generated from the server-side events, which are used to sho
 | **Label** | **Example** | **Notes** |
 | --- | --- | --- |
 | `request_content` | select employee | SQL of MySQL. SQL has been truncated to avoid high-cardinality. The format is ['operation' 'space' 'table']. |
-| `response_content` | 1064 | Error code of MySQL. Only applicable when the response is in error type. |
+| `response_content` | 1064 | Error code of MySQL. Only applicable when the response is in error type. See [codes introduction](https://dev.mysql.com/doc/mysql-errors/5.7/en/error-reference-introduction.html).|
 
 - When protocol is `kafka`:
   
@@ -66,7 +66,7 @@ Service metrics are generated from the server-side events, which are used to sho
 | **Label** | **Example**                   | **Notes**                           |
 | --- |-------------------------|--------------------------|
 | `request_content` | io.kindling.dubbo.api.service.OrderService#order | Service Info. The format of service is `package.class#method`                                                                                            |
-| `response_content` | 20                                               | "error_code" of Dubbo. 20 means OK, more details at `https://dubbo.apache.org/en/blog/2018/10/05/introduction-to-the-dubbo-protocol/#dubbo-protocol-details` |
+| `response_content` | 20 | "error_code" of Dubbo. 20 means OK, more details at the [docs](https://dubbo.apache.org/en/blog/2018/10/05/introduction-to-the-dubbo-protocol/#dubbo-protocol-details). |
 
 - For other cases, the `request_content` and `response_content` are both empty.
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Export the trace of MySQL request when it contains an error.
1. Add the field `is_error` to the attributes map when parsing a MySQL request. The data will be exported as a trace automatically with this field.
2. Update the metric description document.