### PR TITLE
Rewrite the onUpdate and delete method of pod 

### DIFF
--- a/collector/metadata/kubernetes/k8scache.go
+++ b/collector/metadata/kubernetes/k8scache.go
@@ -17,6 +17,7 @@ type K8sPodInfo struct {
 	Ip           string
 	PodName      string
 	Ports        []int32
+	HostPorts    []int32
 	ContainerIds []string
 	Labels       map[string]string
 	// TODO: There may be multiple kinds of workload or services for the same pod

--- a/collector/metadata/kubernetes/k8scache.go
+++ b/collector/metadata/kubernetes/k8scache.go
@@ -14,8 +14,11 @@ type K8sContainerInfo struct {
 }
 
 type K8sPodInfo struct {
-	Ip      string
-	PodName string
+	Ip           string
+	PodName      string
+	Ports        []int32
+	ContainerIds []string
+	Labels       map[string]string
 	// TODO: There may be multiple kinds of workload or services for the same pod
 	WorkloadKind  string
 	WorkloadName  string

--- a/collector/metadata/kubernetes/pod_delete_test.go
+++ b/collector/metadata/kubernetes/pod_delete_test.go
@@ -8,20 +8,12 @@ import (
 func TestDeleteLoop(t *testing.T) {
 	pod := CreatePod(true)
 	onAdd(pod)
-	_, ok := globalPodInfo.get("CustomNamespace", "deploy-1a2b3c4d-5e6f7")
-	if !ok {
-		t.Fatalf("Finding pod at globalPodInfo. Expect %v, but get %v", true, ok)
-	}
 	verifyIfPodExist(true, t)
 	if len(podDeleteQueue) != 0 {
 		t.Fatalf("PodDeleteQueue should be 0, but is %d", len(podDeleteQueue))
 	}
 
 	onDelete(pod)
-	_, ok = globalPodInfo.get("CustomNamespace", "deploy-1a2b3c4d-5e6f7")
-	if ok {
-		t.Fatalf("Finding pod at globalPodInfo. Expect %v, but get %v", false, ok)
-	}
 	verifyIfPodExist(true, t)
 	if len(podDeleteQueue) != 1 {
 		t.Fatalf("PodDeleteQueue should be 1, but is %d", len(podDeleteQueue))
@@ -52,7 +44,11 @@ func TestDeleteLoop(t *testing.T) {
 }
 
 func verifyIfPodExist(exist bool, t *testing.T) {
-	_, ok := MetaDataCache.GetByContainerId("1a2b3c4d5e6f")
+	_, ok := globalPodInfo.get("CustomNamespace", "deploy-1a2b3c4d-5e6f7")
+	if ok != exist {
+		t.Fatalf("Finding pod at globalPodInfo. Expect %v, but get %v", false, ok)
+	}
+	_, ok = MetaDataCache.GetByContainerId("1a2b3c4d5e6f")
 	if ok != exist {
 		t.Errorf("Finding container using containerid. Expect %v, but get %v", exist, ok)
 	}

--- a/collector/metadata/kubernetes/pod_watch.go
+++ b/collector/metadata/kubernetes/pod_watch.go
@@ -294,13 +294,21 @@ func OnUpdate(objOld interface{}, objNew interface{}) {
 		}
 	}
 
-	portsCompare := compare.NewInt32Slice(oldCachePod.Ports, newPorts)
-	portsCompare.Compare()
-	deletedPodInfo.ports = portsCompare.GetRemovedElements()
+	if oldPod.Status.PodIP != newPod.Status.PodIP {
+		deletedPodInfo.ports = oldCachePod.Ports
+	} else {
+		portsCompare := compare.NewInt32Slice(oldCachePod.Ports, newPorts)
+		portsCompare.Compare()
+		deletedPodInfo.ports = portsCompare.GetRemovedElements()
+	}
 
-	hostPortsCompare := compare.NewInt32Slice(oldCachePod.HostPorts, newHostPorts)
-	hostPortsCompare.Compare()
-	deletedPodInfo.hostPorts = hostPortsCompare.GetRemovedElements()
+	if oldPod.Status.HostIP != newPod.Status.HostIP {
+		deletedPodInfo.hostPorts = oldCachePod.Ports
+	} else {
+		hostPortsCompare := compare.NewInt32Slice(oldCachePod.HostPorts, newHostPorts)
+		hostPortsCompare.Compare()
+		deletedPodInfo.hostPorts = hostPortsCompare.GetRemovedElements()
+	}
 
 	// Wait for a few seconds to remove the cache data
 	podDeleteQueueMut.Lock()

--- a/collector/metadata/kubernetes/pod_watch.go
+++ b/collector/metadata/kubernetes/pod_watch.go
@@ -303,7 +303,7 @@ func OnUpdate(objOld interface{}, objNew interface{}) {
 	}
 
 	if oldPod.Status.HostIP != newPod.Status.HostIP {
-		deletedPodInfo.hostPorts = oldCachePod.Ports
+		deletedPodInfo.hostPorts = oldCachePod.HostPorts
 	} else {
 		hostPortsCompare := compare.NewInt32Slice(oldCachePod.HostPorts, newHostPorts)
 		hostPortsCompare.Compare()

--- a/collector/metadata/kubernetes/pod_watch.go
+++ b/collector/metadata/kubernetes/pod_watch.go
@@ -266,7 +266,7 @@ func OnUpdate(objOld interface{}, objNew interface{}) {
 
 	// Check the containers' ID
 	newContainerIds := make([]string, 0)
-	for _, containerStatus := range oldPod.Status.ContainerStatuses {
+	for _, containerStatus := range newPod.Status.ContainerStatuses {
 		shortenContainerId := TruncateContainerId(containerStatus.ContainerID)
 		if shortenContainerId == "" {
 			continue

--- a/collector/metadata/kubernetes/pod_watch_test.go
+++ b/collector/metadata/kubernetes/pod_watch_test.go
@@ -251,3 +251,88 @@ func TestUpdateAndDelayDelete(t *testing.T) {
 
 	stopCh <- struct{}{}
 }
+
+func TestUpdateAndDelayDeleteWhenOnlyPodIpChanged(t *testing.T) {
+	addObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"resourceVersion\":\"44895976\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9001,\"protocol\":\"TCP\",\"hostPort\":9001}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.210\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d505f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
+	updateObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"resourceVersion\":\"44895977\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9001,\"protocol\":\"TCP\",\"hostPort\":9001}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.212\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d000f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
+	addObj := new(corev1.Pod)
+	json.Unmarshal([]byte(addObjJson), addObj)
+	updateObj := new(corev1.Pod)
+	json.Unmarshal([]byte(updateObjJson), updateObj)
+	port := addObj.Spec.Containers[0].Ports[0].ContainerPort
+	onAdd(addObj)
+	stopCh := make(chan struct{})
+	go podDeleteLoop(100*time.Millisecond, 500*time.Millisecond, stopCh)
+	OnUpdate(addObj, updateObj)
+
+	// Check if new Container can be find
+	_, find := MetaDataCache.GetByContainerId(TruncateContainerId(updateObj.Status.ContainerStatuses[0].ContainerID))
+	assert.True(t, find, "NewContainerId did't find in MetaDataCache")
+	_, find = MetaDataCache.GetContainerByIpPort(updateObj.Status.PodIP, uint32(port))
+	assert.True(t, find, "NewContainer IP Port did't find in MetaDataCache")
+	_, find = MetaDataCache.GetContainerByHostIpPort(updateObj.Status.HostIP, uint32(port))
+	assert.True(t, find, "NewHostIp Port did't find in MetaDataCache")
+
+	// Wait for deletes
+	time.Sleep(1000 * time.Millisecond)
+
+	// Double Check for NewContainer
+	_, find = MetaDataCache.GetByContainerId(TruncateContainerId(updateObj.Status.ContainerStatuses[0].ContainerID))
+	assert.True(t, find, "NewContainerId did't find in MetaDataCache")
+	_, find = MetaDataCache.GetContainerByIpPort(updateObj.Status.PodIP, uint32(port))
+	assert.True(t, find, "NewContainer IP Port did't find in MetaDataCache")
+	_, find = MetaDataCache.GetContainerByHostIpPort(updateObj.Status.HostIP, uint32(port))
+	assert.True(t, find, "NewHostIp Port did't find in MetaDataCache")
+
+	// Check the old Container has been delete
+	_, find = MetaDataCache.GetByContainerId(TruncateContainerId(addObj.Status.ContainerStatuses[0].ContainerID))
+	assert.False(t, find, "OldContainerId should be deletedin MetaDataCache")
+	_, find = MetaDataCache.GetContainerByIpPort(addObj.Status.PodIP, uint32(port))
+	assert.False(t, find, "OldContainer IP should be deleted in MetaDataCache")
+
+	stopCh <- struct{}{}
+}
+
+func TestUpdateAndDelayDeleteWhenOnlyPortChanged(t *testing.T) {
+	addObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"resourceVersion\":\"44895976\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9001,\"protocol\":\"TCP\",\"hostPort\":9001}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.210\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d505f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
+	updateObjJson := "{\"metadata\":{\"name\":\"testdemo2-5c86748464-26crb\",\"namespace\":\"test-ns\",\"resourceVersion\":\"44895977\"},\"spec\":{\"containers\":[{\"name\":\"testdemo2\",\"ports\":[{\"containerPort\":9002,\"protocol\":\"TCP\",\"hostPort\":9002}]}]},\"status\":{\"phase\":\"Running\",\"podIP\":\"192.168.136.210\",\"hostIP\":\"10.10.10.101\",\"containerStatuses\":[{\"name\":\"testdemo2\",\"state\":{\"running\":{\"startedAt\":\"2022-05-25T08:55:36Z\"}},\"lastState\":{},\"ready\":true,\"restartCount\":5,\"image\":\"\",\"imageID\":\"docker-pullable://10.10.102.213:8443/cloudnevro-test/test-netserver@sha256:6720f648b74ed590f36094a1c7a58b01b6881396409784c17f471ecfe445e3fd\",\"containerID\":\"docker://d000f50edb4e204cf31840e3cb8d26d33f212d4ebef994d0c3fc151d57e17413\",\"started\":true}]}}"
+	addObj := new(corev1.Pod)
+	json.Unmarshal([]byte(addObjJson), addObj)
+	updateObj := new(corev1.Pod)
+	json.Unmarshal([]byte(updateObjJson), updateObj)
+	port := addObj.Spec.Containers[0].Ports[0].ContainerPort
+	newPort := updateObj.Spec.Containers[0].Ports[0].ContainerPort
+	onAdd(addObj)
+	stopCh := make(chan struct{})
+	go podDeleteLoop(100*time.Millisecond, 500*time.Millisecond, stopCh)
+	OnUpdate(addObj, updateObj)
+
+	// Check if new Container can be find
+	_, find := MetaDataCache.GetByContainerId(TruncateContainerId(updateObj.Status.ContainerStatuses[0].ContainerID))
+	assert.True(t, find, "NewContainerId did't find in MetaDataCache")
+	_, find = MetaDataCache.GetContainerByIpPort(updateObj.Status.PodIP, uint32(newPort))
+	assert.True(t, find, "NewContainer IP Port did't find in MetaDataCache")
+	_, find = MetaDataCache.GetContainerByHostIpPort(updateObj.Status.HostIP, uint32(newPort))
+	assert.True(t, find, "NewHostIp Port did't find in MetaDataCache")
+
+	// Wait for deletes
+	time.Sleep(1000 * time.Millisecond)
+
+	// Double Check for NewContainer
+	_, find = MetaDataCache.GetByContainerId(TruncateContainerId(updateObj.Status.ContainerStatuses[0].ContainerID))
+	assert.True(t, find, "NewContainerId did't find in MetaDataCache")
+	_, find = MetaDataCache.GetContainerByIpPort(updateObj.Status.PodIP, uint32(newPort))
+	assert.True(t, find, "NewContainer IP Port did't find in MetaDataCache")
+	_, find = MetaDataCache.GetContainerByHostIpPort(updateObj.Status.HostIP, uint32(newPort))
+	assert.True(t, find, "NewHostIp Port did't find in MetaDataCache")
+
+	// Check the old Container has been delete
+	_, find = MetaDataCache.GetByContainerId(TruncateContainerId(addObj.Status.ContainerStatuses[0].ContainerID))
+	assert.False(t, find, "OldContainerId should be deletedin MetaDataCache")
+	_, find = MetaDataCache.GetContainerByIpPort(addObj.Status.PodIP, uint32(port))
+	assert.True(t, find, "If podIp is not changed , Old IP can still be found in MetaDataCache")
+	_, find = MetaDataCache.GetContainerByHostIpPort(addObj.Status.HostIP, uint32(port))
+	assert.False(t, find, "OldHostIp Port should be deleted in MetaDataCache")
+
+	stopCh <- struct{}{}
+}

--- a/collector/metadata/kubernetes/pod_watch_test.go
+++ b/collector/metadata/kubernetes/pod_watch_test.go
@@ -32,7 +32,7 @@ func TestTruncateContainerId(t *testing.T) {
 
 func TestOnAdd(t *testing.T) {
 	globalPodInfo = &podMap{
-		Info: make(map[string]map[string]*PodInfo),
+		Info: make(map[string]map[string]*K8sPodInfo),
 	}
 	globalServiceInfo = &ServiceMap{
 		ServiceMap: make(map[string]map[string]*K8sServiceInfo),
@@ -56,7 +56,7 @@ func TestOnAdd(t *testing.T) {
 // ISSUE https://github.com/CloudDectective-Harmonycloud/kindling/issues/229
 func TestOnAddPodWhileReplicaSetUpdating(t *testing.T) {
 	globalPodInfo = &podMap{
-		Info: make(map[string]map[string]*PodInfo),
+		Info: make(map[string]map[string]*K8sPodInfo),
 	}
 	globalServiceInfo = &ServiceMap{
 		ServiceMap: make(map[string]map[string]*K8sServiceInfo),
@@ -98,7 +98,7 @@ func TestOnAddPodWhileReplicaSetUpdating(t *testing.T) {
 
 func TestOnAddLowercaseWorkload(t *testing.T) {
 	globalPodInfo = &podMap{
-		Info: make(map[string]map[string]*PodInfo),
+		Info: make(map[string]map[string]*K8sPodInfo),
 	}
 	globalServiceInfo = &ServiceMap{
 		ServiceMap: make(map[string]map[string]*K8sServiceInfo),

--- a/collector/metadata/kubernetes/service_watch_test.go
+++ b/collector/metadata/kubernetes/service_watch_test.go
@@ -1,10 +1,11 @@
 package kubernetes
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestSelectorsMatchLabels(t *testing.T) {
@@ -116,7 +117,7 @@ func TestServiceMap_GetServiceMatchLabels(t *testing.T) {
 
 func TestOnAddService(t *testing.T) {
 	globalPodInfo = &podMap{
-		Info: make(map[string]map[string]*PodInfo),
+		Info: make(map[string]map[string]*K8sPodInfo),
 	}
 	globalServiceInfo = &ServiceMap{
 		ServiceMap: make(map[string]map[string]*K8sServiceInfo),
@@ -139,7 +140,7 @@ func TestOnAddService(t *testing.T) {
 
 func TestServiceMap_Delete(t *testing.T) {
 	globalPodInfo = &podMap{
-		Info: make(map[string]map[string]*PodInfo),
+		Info: make(map[string]map[string]*K8sPodInfo),
 	}
 	globalServiceInfo = &ServiceMap{
 		ServiceMap: make(map[string]map[string]*K8sServiceInfo),

--- a/collector/pkg/compare/int32_slice.go
+++ b/collector/pkg/compare/int32_slice.go
@@ -1,0 +1,49 @@
+package compare
+
+type Int32Slice struct {
+	oldElements []int32
+	oldFlags    []bool
+	newElements []int32
+	newFlags    []bool
+}
+
+func NewInt32Slice(oldElements []int32, newElements []int32) Int32Slice {
+	return Int32Slice{
+		oldElements: oldElements,
+		oldFlags:    make([]bool, len(oldElements)),
+		newElements: newElements,
+		newFlags:    make([]bool, len(newElements)),
+	}
+}
+
+func (c *Int32Slice) Compare() {
+	// The elements could be repeated, so we must iterate all the elements.
+	for i, newElement := range c.newElements {
+		for j, oldElement := range c.oldElements {
+			if oldElement == newElement {
+				c.newFlags[i] = true
+				c.oldFlags[j] = true
+			}
+		}
+	}
+}
+
+func (c *Int32Slice) GetRemovedElements() []int32 {
+	ret := make([]int32, 0)
+	for i, flag := range c.oldFlags {
+		if !flag {
+			ret = append(ret, c.oldElements[i])
+		}
+	}
+	return ret
+}
+
+func (c *Int32Slice) GetAddedElements() []int32 {
+	ret := make([]int32, 0)
+	for i, flag := range c.newFlags {
+		if !flag {
+			ret = append(ret, c.newElements[i])
+		}
+	}
+	return ret
+}

--- a/collector/pkg/compare/slice_test.go
+++ b/collector/pkg/compare/slice_test.go
@@ -1,0 +1,29 @@
+package compare
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInt32Slice(t *testing.T) {
+	oldElements := []int32{0, 0, 1, 2, 3}
+	newElements := []int32{1, 3, 4, 6}
+	compareSlice := NewInt32Slice(oldElements, newElements)
+	compareSlice.Compare()
+	removedElements := compareSlice.GetRemovedElements()
+	assert.ElementsMatch(t, removedElements, []int32{0, 0, 2})
+	addedElements := compareSlice.GetAddedElements()
+	assert.ElementsMatch(t, addedElements, []int32{4, 6})
+}
+
+func TestStringSlice(t *testing.T) {
+	oldElements := []string{"a", "b", "c"}
+	newElements := []string{"d", "e", "f"}
+	compareSlice := NewStringSlice(oldElements, newElements)
+	compareSlice.Compare()
+	removedElements := compareSlice.GetRemovedElements()
+	assert.ElementsMatch(t, removedElements, []string{"a", "b", "c"})
+	addedElements := compareSlice.GetAddedElements()
+	assert.ElementsMatch(t, addedElements, []string{"d", "e", "f"})
+}

--- a/collector/pkg/compare/string_slice.go
+++ b/collector/pkg/compare/string_slice.go
@@ -1,0 +1,49 @@
+package compare
+
+type StringSlice struct {
+	oldElements []string
+	oldFlags    []bool
+	newElements []string
+	newFlags    []bool
+}
+
+func NewStringSlice(oldElements []string, newElements []string) StringSlice {
+	return StringSlice{
+		oldElements: oldElements,
+		oldFlags:    make([]bool, len(oldElements)),
+		newElements: newElements,
+		newFlags:    make([]bool, len(newElements)),
+	}
+}
+
+func (c *StringSlice) Compare() {
+	// The elements could be repeated, so we must iterate all the elements.
+	for i, newElement := range c.newElements {
+		for j, oldElement := range c.oldElements {
+			if oldElement == newElement {
+				c.newFlags[i] = true
+				c.oldFlags[j] = true
+			}
+		}
+	}
+}
+
+func (c *StringSlice) GetRemovedElements() []string {
+	ret := make([]string, 0)
+	for i, flag := range c.oldFlags {
+		if !flag {
+			ret = append(ret, c.oldElements[i])
+		}
+	}
+	return ret
+}
+
+func (c *StringSlice) GetAddedElements() []string {
+	ret := make([]string, 0)
+	for i, flag := range c.newFlags {
+		if !flag {
+			ret = append(ret, c.newElements[i])
+		}
+	}
+	return ret
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
1. Replace PodInfo with k8sPodInfo in the globalPodInfo. This helps reduce the complexity of the data structure of pods. 
2. Only delete the desired fields of pods when delayed deleting.
3. Rewrite the `onUpdate` method to avoid the delayed deleting requests removing everything.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
#239 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Now the test case that failed before is passed.
```
=== RUN   TestUpdateDelayDelete
    pod_watch_test.go:218: Found container [192.168.136.210:9001]
    pod_watch_test.go:228: Found container [192.168.136.210:9001]
--- PASS: TestUpdateDelayDelete (0.61s)
PASS
```