### PR TITLE
Always add duration metric to tcp_connect_data_group

### DIFF
--- a/collector/analyzer/tcpconnectanalyzer/analyzer.go
+++ b/collector/analyzer/tcpconnectanalyzer/analyzer.go
@@ -182,6 +182,8 @@ func (a *TcpConnectAnalyzer) generateDataGroup(connectStats *internal.Connection
 	// Only record the connection's duration when it is successfully established
 	if connectStats.StateMachine.GetCurrentState() == internal.Success {
 		metrics = append(metrics, model.NewIntMetric(constnames.TcpConnectDurationMetric, connectStats.GetConnectDuration()))
+	} else {
+		metrics = append(metrics, model.NewIntMetric(constnames.TcpConnectDurationMetric, 0))
 	}
 
 	retDataGroup := model.NewDataGroup(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Always add duration metric to `tcp_connect_data_group`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The structure `DataGroup` is used to group a set of metrics that contain the same labels. Any group should have a clear definition of its values and labels. The `tcp_connect_data_group` should always contain two values but has missed the `duration` value when the connection failed to be established. This makes it inconvenient for users willing to process the data further since they cannot make sure what values it contains.
