### PR TITLE
k8sprocessor: use src IP for further searching if the dst IP is a loopback address

### DIFF
--- a/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
+++ b/collector/consumer/processor/k8sprocessor/kubernetes_processor.go
@@ -121,6 +121,8 @@ func (p *K8sMetadataProcessor) addK8sMetaDataForClientLabel(labelMap *model.Attr
 	if dstIp == loopbackIp {
 		labelMap.UpdateAddStringValue(constlabels.DstNodeIp, p.localNodeIp)
 		labelMap.UpdateAddStringValue(constlabels.DstNode, p.localNodeName)
+		// If the dst IP is a loopback address, we use its src IP for further searching.
+		dstIp = labelMap.GetStringValue(constlabels.SrcIp)
 	}
 	dstPort := labelMap.GetIntValue(constlabels.DstPort)
 	// DstIp is IP of a service


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use src IP for further searching if the dst IP is a loopback address.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I found there are some cases where the containers use the loopback address to send requests to the containers in the same pod, such as `node-exporter`. In these cases, the destination IP is `127.0.0.1` with which we can't find the pod information, but the source IP is correct which can be used to search for the destination pod.