### PR TITLE
use the tcp_close events to generate the srtt metric

### DIFF
--- a/collector/analyzer/tcpmetricanalyzer/tcp_analyzer.go
+++ b/collector/analyzer/tcpmetricanalyzer/tcp_analyzer.go
@@ -57,6 +57,7 @@ func (a *TcpMetricAnalyzer) ConsumeEvent(event *model.KindlingEvent) error {
 	var err error
 	switch event.Name {
 	case constnames.TcpCloseEvent:
+		fallthrough
 	case constnames.TcpRcvEstablishedEvent:
 		dataGroup, err = a.generateRtt(event)
 	case constnames.TcpDropEvent:


### PR DESCRIPTION
Fix the bug that the `tcpmetricanalyzer` skips the `tcp_close` event incorrectly.