### PR TITLE
Add a URL clustering method to reduce the cardinality

### DIFF
--- a/collector/analyzer/network/config.go
+++ b/collector/analyzer/network/config.go
@@ -17,8 +17,58 @@ type Config struct {
 	ConntrackRateLimit    int    `mapstructure:"conntrack_rate_limit"`
 	ProcRoot              string `mapstructure:"proc_root"`
 
-	ProtocolParser  []string         `mapstructure:"protocol_parser"`
-	ProtocolConfigs []ProtocolConfig `mapstructure:"protocol_config,omitempty"`
+	ProtocolParser      []string         `mapstructure:"protocol_parser"`
+	ProtocolConfigs     []ProtocolConfig `mapstructure:"protocol_config,omitempty"`
+	UrlClusteringMethod string           `mapstructure:"url_clustering_method"`
+}
+
+func NewDefaultConfig() *Config {
+	return &Config{
+		ConnectTimeout:        100,
+		RequestTimeout:        60,
+		ResponseSlowThreshold: 500,
+		EnableConntrack:       true,
+		ConntrackMaxStateSize: 131072,
+		ConntrackRateLimit:    500,
+		ProcRoot:              "/proc",
+		ProtocolParser:        []string{"http", "mysql", "dns", "redis", "kafka", "dubbo"},
+		ProtocolConfigs: []ProtocolConfig{
+			{
+				Key:           "http",
+				PayloadLength: 200,
+			},
+			{
+				Key:           "dubbo",
+				PayloadLength: 200,
+			},
+			{
+				Key:       "mysql",
+				Ports:     []uint32{3306},
+				Threshold: 100,
+			},
+			{
+				Key:       "kafka",
+				Ports:     []uint32{9092},
+				Threshold: 100,
+			},
+			{
+				Key:       "dns",
+				Ports:     []uint32{53},
+				Threshold: 100,
+			},
+			{
+				Key:       "cassandra",
+				Ports:     []uint32{9042},
+				Threshold: 100,
+			},
+			{
+				Key:       "s3",
+				Ports:     []uint32{9190},
+				Threshold: 100,
+			},
+		},
+		UrlClusteringMethod: "alphabet",
+	}
 }
 
 type ProtocolConfig struct {

--- a/collector/analyzer/network/protocol/factory/config.go
+++ b/collector/analyzer/network/protocol/factory/config.go
@@ -1,0 +1,19 @@
+package factory
+
+type config struct {
+	urlClusteringMethod string
+}
+
+func newDefaultConfig() *config {
+	return &config{
+		urlClusteringMethod: "alphabet",
+	}
+}
+
+type Option func(cfg *config)
+
+func WithUrlClusteringMethod(urlClusteringMethod string) Option {
+	return func(cfg *config) {
+		cfg.urlClusteringMethod = urlClusteringMethod
+	}
+}

--- a/collector/analyzer/network/protocol/http/http_parser.go
+++ b/collector/analyzer/network/protocol/http/http_parser.go
@@ -4,10 +4,20 @@ import (
 	"strings"
 
 	"github.com/Kindling-project/kindling/collector/analyzer/network/protocol"
+	"github.com/Kindling-project/kindling/collector/pkg/urlclustering"
 )
 
-func NewHttpParser() *protocol.ProtocolParser {
-	requestParser := protocol.CreatePkgParser(fastfailHttpRequest(), parseHttpRequest())
+func NewHttpParser(urlClusteringMethod string) *protocol.ProtocolParser {
+	var method urlclustering.ClusteringMethod
+	switch urlClusteringMethod {
+	case "alphabet":
+		method = urlclustering.NewAlphabeticalClusteringMethod()
+	case "noparam":
+		method = urlclustering.NewNoParamClusteringMethod()
+	default:
+		method = urlclustering.NewAlphabeticalClusteringMethod()
+	}
+	requestParser := protocol.CreatePkgParser(fastfailHttpRequest(), parseHttpRequest(method))
 	responseParser := protocol.CreatePkgParser(fastfailHttpResponse(), parseHttpResponse())
 
 	return protocol.NewProtocolParser(protocol.HTTP, requestParser, responseParser, nil)

--- a/collector/analyzer/network/protocol/http/http_parser_test.go
+++ b/collector/analyzer/network/protocol/http/http_parser_test.go
@@ -98,7 +98,7 @@ func TestParseHttpRequest_GetPayLoad(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			protocol.SetPayLoadLength(protocol.HTTP, tt.size)
 			message := protocol.NewRequestMessage([]byte(httpData))
-			NewHttpParser().ParseRequest(message)
+			NewHttpParser("").ParseRequest(message)
 
 			if !message.HasAttribute(constlabels.HttpRequestPayload) {
 				t.Errorf("Fail to parse HttpRequest()")
@@ -127,7 +127,7 @@ func TestParseHttpResponse_GetPayLoad(t *testing.T) {
 			protocol.SetPayLoadLength(protocol.HTTP, tt.size)
 
 			message := protocol.NewResponseMessage([]byte(httpData), model.NewAttributeMap())
-			NewHttpParser().ParseResponse(message)
+			NewHttpParser("").ParseResponse(message)
 
 			if !message.HasAttribute(constlabels.HttpResponsePayload) {
 				t.Errorf("Fail to parse HttpResponse()")

--- a/collector/analyzer/network/protocol/http/http_request.go
+++ b/collector/analyzer/network/protocol/http/http_request.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/Kindling-project/kindling/collector/analyzer/tools"
+	"github.com/Kindling-project/kindling/collector/pkg/urlclustering"
 
 	"github.com/Kindling-project/kindling/collector/analyzer/network/protocol"
 	"github.com/Kindling-project/kindling/collector/model/constlabels"
@@ -55,7 +56,7 @@ func parseHttpRequest() protocol.ParsePkgFn {
 		message.AddByteArrayUtf8Attribute(constlabels.HttpUrl, url)
 		message.AddByteArrayUtf8Attribute(constlabels.HttpRequestPayload, message.GetData(0, protocol.GetHttpPayLoadLength()))
 
-		contentKey := getContentKey(string(url))
+		contentKey := urlclustering.AlphabeticClustering(string(url))
 		if len(contentKey) == 0 {
 			contentKey = "*"
 		}

--- a/collector/analyzer/network/protocol/http/http_request.go
+++ b/collector/analyzer/network/protocol/http/http_request.go
@@ -27,7 +27,7 @@ Request line
 Request header
 Request body
 */
-func parseHttpRequest() protocol.ParsePkgFn {
+func parseHttpRequest(urlClusteringMethod urlclustering.ClusteringMethod) protocol.ParsePkgFn {
 	return func(message *protocol.PayloadMessage) (bool, bool) {
 		offset, method := message.ReadUntilBlankWithLength(message.Offset, 8)
 
@@ -56,7 +56,7 @@ func parseHttpRequest() protocol.ParsePkgFn {
 		message.AddByteArrayUtf8Attribute(constlabels.HttpUrl, url)
 		message.AddByteArrayUtf8Attribute(constlabels.HttpRequestPayload, message.GetData(0, protocol.GetHttpPayLoadLength()))
 
-		contentKey := urlclustering.AlphabeticClustering(string(url))
+		contentKey := urlClusteringMethod.Clustering(string(url))
 		if len(contentKey) == 0 {
 			contentKey = "*"
 		}

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -49,7 +49,8 @@ analyzers:
     # The protocol parsers which is enabled
     # When dissectors are enabled, agent will analyze the payload and enrich metric/trace with its content.
     protocol_parser: [ http, mysql, dns, redis, kafka, dubbo ]
-    # Which URL clustering method should be used.
+    # Which URL clustering method should be used to shorten the URL of HTTP request.
+    # This is useful for decrease the cardinality of URLs.
     # Valid values: ["noparam", "alphabet"]
     # - noparam: Only trim the trailing parameters behind the character '?'
     # - alphabet: Trim the trailing parameters and Convert the segments

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -49,6 +49,12 @@ analyzers:
     # The protocol parsers which is enabled
     # When dissectors are enabled, agent will analyze the payload and enrich metric/trace with its content.
     protocol_parser: [ http, mysql, dns, redis, kafka, dubbo ]
+    # Which URL clustering method should be used.
+    # Valid values: ["noparam", "alphabet"]
+    # - noparam: Only trim the trailing parameters behind the character '?'
+    # - alphabet: Trim the trailing parameters and Convert the segments
+    #             containing non-alphabetical characters to star(*)
+    url_clustering_method: alphabet
     # If the destination port of data is one of the followings, the protocol of such network request
     # is set to the corresponding one. Note the program will try to identify the protocol automatically
     # for the ports that are not in the lists, in which case the cpu usage will be increased much inevitably.

--- a/collector/pkg/urlclustering/alphabet.go
+++ b/collector/pkg/urlclustering/alphabet.go
@@ -1,0 +1,105 @@
+package urlclustering
+
+import (
+	"regexp"
+	"strings"
+)
+
+// AlphabeticClusteringMethod clustering all the non-alphabetic characters to '*'
+// and will trim the parameters at the end of the string.
+type AlphabeticClusteringMethod struct {
+	regexp *regexp.Regexp
+}
+
+func NewAlphabeticalClusteringMethod() *AlphabeticClusteringMethod {
+	exp, _ := regexp.Compile("^[A-Za-z_-]+$")
+	return &AlphabeticClusteringMethod{
+		regexp: exp,
+	}
+}
+
+func (m *AlphabeticClusteringMethod) ClusteringBaseline(endpoint string) string {
+	if endpoint == "" {
+		return ""
+	}
+	index := strings.Index(endpoint, "?")
+	if index != -1 {
+		endpoint = endpoint[:index]
+	}
+
+	// Split the endpoint into multiple segments
+	endpoint = strings.TrimSpace(endpoint)
+	segments := strings.Split(endpoint, "/")
+	// Iterate over all parts and execute the regular expression.
+	resultSegments := make([]string, 0, len(segments))
+	// Skip the first segment because it is supposed to be always empty.
+	for i := 1; i < len(segments); i++ {
+		if segments[i] == "" || m.regexp.MatchString(segments[i]) {
+			resultSegments = append(resultSegments, segments[i])
+		} else {
+			// If the segment is composed of non-alphabetic characters, we replace it with a star.
+			resultSegments = append(resultSegments, "*")
+		}
+	}
+	// Re-combine all parts together
+	var resultEndpoint string
+	for _, seg := range resultSegments {
+		resultEndpoint = resultEndpoint + "/" + seg
+	}
+
+	return resultEndpoint
+}
+
+func (m *AlphabeticClusteringMethod) Clustering(endpoint string) string {
+	if endpoint == "" {
+		return ""
+	}
+	endpointBytes := []byte(endpoint)
+
+	resultBytes := make([]byte, 0)
+
+	currentSegmentIsStar := false
+	currentSegment := make([]byte, 0)
+
+	for _, b := range endpointBytes {
+		if b == ' ' {
+			continue
+		}
+		// End of the current segment.
+		if b == '/' || b == '?' {
+			if currentSegmentIsStar {
+				resultBytes = append(resultBytes, '*')
+			} else {
+				// currentSegment could be empty
+				resultBytes = append(resultBytes, currentSegment...)
+			}
+			currentSegment = make([]byte, 0)
+			currentSegmentIsStar = false
+			if b == '/' {
+				resultBytes = append(resultBytes, '/')
+				continue
+			} else if b == '?' {
+				break
+			}
+		}
+		if currentSegmentIsStar {
+			continue
+		}
+		if isAlphabetical(b) {
+			currentSegment = append(currentSegment, b)
+		} else {
+			currentSegmentIsStar = true
+		}
+	}
+	// Deal with the last segment.
+	if currentSegmentIsStar {
+		resultBytes = append(resultBytes, '*')
+	} else if len(currentSegment) != 0 {
+		resultBytes = append(resultBytes, currentSegment...)
+	}
+	return string(resultBytes)
+}
+
+func isAlphabetical(b byte) bool {
+	return b == '-' || b == '_' || (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}

--- a/collector/pkg/urlclustering/alphabet_test.go
+++ b/collector/pkg/urlclustering/alphabet_test.go
@@ -13,13 +13,17 @@ type testCase struct {
 
 func newTestcases() []testCase {
 	return []testCase{
+		{"", ""},
 		{"/", "/"},
-		{"/A/b/20000/", "/A/b/*/"},
-		{" /test/22?v=a", "/test/*"},
-		{"/a12?a=1132", "/*"},
+		{"/A/b/_20000/", "/A/b/*/"},
+		{" /test_a/22?v=a", "/test_a/*"},
+		{"/a-12?a=1132", "/*"},
 		{"/abcd/1234a/efg/b&*", "/abcd/*/efg/*"},
 		// Double slashes is valid but not recommended
 		{"/a//b/c?d=2&e=3", "/a//b/c"},
+		// Although this is not a valid endpoint, we still accept it.
+		{"noslash/and/1234", "noslash/and/*"},
+		{"/a/b/it-is-a-long-segment-like-uuid-or-document-name-or-something-wired?v=1&b=3", "/a/b/*"},
 	}
 }
 

--- a/collector/pkg/urlclustering/alphabet_test.go
+++ b/collector/pkg/urlclustering/alphabet_test.go
@@ -1,0 +1,83 @@
+package urlclustering
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testCase struct {
+	endpoint string
+	want     string
+}
+
+func newTestcases() []testCase {
+	return []testCase{
+		{"/", "/"},
+		{"/A/b/20000/", "/A/b/*/"},
+		{" /test/22?v=a", "/test/*"},
+		{"/a12?a=1132", "/*"},
+		{"/abcd/1234a/efg/b&*", "/abcd/*/efg/*"},
+		// Double slashes is valid but not recommended
+		{"/a//b/c?d=2&e=3", "/a//b/c"},
+	}
+}
+
+func TestAlphabeticClusteringMethod_Clustering(t *testing.T) {
+	method := NewAlphabeticalClusteringMethod()
+	testCases := newTestcases()
+	for _, c := range testCases {
+		assert.Equal(t, c.want, method.Clustering(c.endpoint))
+	}
+}
+
+func TestAlphabeticClusteringMethod_ClusteringBaseline(t *testing.T) {
+	method := NewAlphabeticalClusteringMethod()
+	testCases := newTestcases()
+	for _, c := range testCases {
+		assert.Equal(t, c.want, method.ClusteringBaseline(c.endpoint))
+	}
+}
+
+func Test_isAlphabetical(t *testing.T) {
+	type args struct {
+		b byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"alphabetical", args{'a'}, true},
+		{"non-alphabetical", args{'%'}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAlphabetical(tt.args.b); got != tt.want {
+				t.Errorf("isAlphabetical() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Benchmark_ClusteringBaseline(b *testing.B) {
+	method := NewAlphabeticalClusteringMethod()
+	testCases := newTestcases()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, c := range testCases {
+			method.ClusteringBaseline(c.endpoint)
+		}
+	}
+}
+
+func Benchmark_Clustering(b *testing.B) {
+	method := NewAlphabeticalClusteringMethod()
+	testCases := newTestcases()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, c := range testCases {
+			method.Clustering(c.endpoint)
+		}
+	}
+}

--- a/collector/pkg/urlclustering/noparam.go
+++ b/collector/pkg/urlclustering/noparam.go
@@ -16,6 +16,7 @@ func (m *NoParamClusteringMethod) Clustering(endpoint string) string {
 	if endpoint == "" {
 		return ""
 	}
+	endpoint = strings.TrimSpace(endpoint)
 	// Remove the parameters first
 	index := strings.Index(endpoint, "?")
 	if index != -1 {

--- a/collector/pkg/urlclustering/noparam.go
+++ b/collector/pkg/urlclustering/noparam.go
@@ -1,0 +1,26 @@
+package urlclustering
+
+import (
+	"strings"
+)
+
+// NoParamClusteringMethod removes the parameters that are end of the URL string.
+type NoParamClusteringMethod struct {
+}
+
+func NewNoParamClusteringMethod() ClusteringMethod {
+	return &NoParamClusteringMethod{}
+}
+
+func (m *NoParamClusteringMethod) Clustering(endpoint string) string {
+	if endpoint == "" {
+		return ""
+	}
+	// Remove the parameters first
+	index := strings.Index(endpoint, "?")
+	if index != -1 {
+		endpoint = endpoint[:index]
+	}
+
+	return endpoint
+}

--- a/collector/pkg/urlclustering/noparam_test.go
+++ b/collector/pkg/urlclustering/noparam_test.go
@@ -1,0 +1,27 @@
+package urlclustering
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func noParamTestcases() []testCase {
+	return []testCase{
+		{"/", "/"},
+		{"/A/b/20000/", "/A/b/20000/"},
+		{" /test/22?v=a", "/test/22"},
+		{"/a12?a=1132", "/a12"},
+		{"/abcd/1234a/efg/b&*", "/abcd/1234a/efg/b&*"},
+		// Double slashes is valid but not recommended
+		{"/a//b/c?d=2&e=3", "/a//b/c"},
+	}
+}
+
+func TestNoParamClusteringMethod_Clustering(t *testing.T) {
+	method := NewNoParamClusteringMethod()
+	testCases := noParamTestcases()
+	for _, c := range testCases {
+		assert.Equal(t, c.want, method.Clustering(c.endpoint))
+	}
+}

--- a/collector/pkg/urlclustering/urlcluster.go
+++ b/collector/pkg/urlclustering/urlcluster.go
@@ -1,0 +1,34 @@
+package urlclustering
+
+type ClusteringMethod interface {
+	// Clustering receives a no-host endpoint string of the HTTP request and
+	// return its clustering result.
+	// Some examples of the endpoint:
+	// - /path/to/file/1
+	// - /part1/part2/2?param=1
+	// - /CloudDetective-Harmonycloud/kindling
+	Clustering(endpoint string) string
+}
+
+var (
+	alphabeticMethod ClusteringMethod
+	noParamMethod    ClusteringMethod
+)
+
+// AlphabeticClustering is a convenient method that calls AlphabeticClusteringMethod.Clustering().
+// This method is not thread-safe.
+func AlphabeticClustering(endpoint string) string {
+	if alphabeticMethod == nil {
+		alphabeticMethod = NewAlphabeticalClusteringMethod()
+	}
+	return alphabeticMethod.Clustering(endpoint)
+}
+
+// NoParamClustering is a global method that calls NoParamClusteringMethod.Clustering().
+// This method is not thread-safe.
+func NoParamClustering(endpoint string) string {
+	if noParamMethod == nil {
+		noParamMethod = NewNoParamClusteringMethod()
+	}
+	return noParamMethod.Clustering(endpoint)
+}

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -49,7 +49,8 @@ analyzers:
     # The protocol parsers which is enabled
     # When dissectors are enabled, agent will analyze the payload and enrich metric/trace with its content.
     protocol_parser: [ http, mysql, dns, redis, kafka, dubbo ]
-    # Which URL clustering method should be used.
+    # Which URL clustering method should be used to shorten the URL of HTTP request.
+    # This is useful for decrease the cardinality of URLs.
     # Valid values: ["noparam", "alphabet"]
     # - noparam: Only trim the trailing parameters behind the character '?'
     # - alphabet: Trim the trailing parameters and Convert the segments

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -49,6 +49,12 @@ analyzers:
     # The protocol parsers which is enabled
     # When dissectors are enabled, agent will analyze the payload and enrich metric/trace with its content.
     protocol_parser: [ http, mysql, dns, redis, kafka, dubbo ]
+    # Which URL clustering method should be used.
+    # Valid values: ["noparam", "alphabet"]
+    # - noparam: Only trim the trailing parameters behind the character '?'
+    # - alphabet: Trim the trailing parameters and Convert the segments
+    #             containing non-alphabetical characters to star(*)
+    url_clustering_method: alphabet
     # If the destination port of data is one of the followings, the protocol of such network request
     # is set to the corresponding one. Note the program will try to identify the protocol automatically
     # for the ports that are not in the lists, in which case the cpu usage will be increased much inevitably.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
1. Add a new `urlclustering` package which contains a `ClusteringMethod` interface and two trivial implementations.
2. Add an option for choosing which URL clustering method is used. `alphabet` is used by default.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
#267 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
**UnitTest**
```
=== RUN   TestAlphabeticClusteringMethod_Clustering
--- PASS: TestAlphabeticClusteringMethod_Clustering (0.00s)
=== RUN   TestAlphabeticClusteringMethod_ClusteringBaseline
--- PASS: TestAlphabeticClusteringMethod_ClusteringBaseline (0.00s)
=== RUN   Test_isAlphabetical
=== RUN   Test_isAlphabetical/alphabetical
=== RUN   Test_isAlphabetical/non-alphabetical
--- PASS: Test_isAlphabetical (0.00s)
    --- PASS: Test_isAlphabetical/alphabetical (0.00s)
    --- PASS: Test_isAlphabetical/non-alphabetical (0.00s)
=== RUN   TestNoParamClusteringMethod_Clustering
--- PASS: TestNoParamClusteringMethod_Clustering (0.00s)
PASS
```
**Benchmark**
```
goos: darwin
goarch: amd64
pkg: github.com/Kindling-project/kindling/collector/pkg/urlclustering
cpu: Intel(R) Core(TM) i5-6267U CPU @ 2.90GHz
Benchmark_ClusteringBaseline
Benchmark_ClusteringBaseline-4   	  171873	      6979 ns/op
Benchmark_Clustering
Benchmark_Clustering-4           	  648603	      1991 ns/op
PASS
```
