### PR TITLE
Declare the 9500 port in the agent's deployment file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 1. All notable changes to this project will be documented in this file.
 2. Records in this file are not identical to the title of their Pull Requests. A detailed description is necessary for understanding what changes are and why they are made.
 
+## Unreleased 
+### Enhancements
+- Declare the 9500 port in the agent's deployment file ([#282](https://github.com/CloudDectective-Harmonycloud/kindling/pull/282))
+
 ## v0.3.0 - 2022-06-29
 ### New features
 - Add a URL clustering method to reduce the cardinality of the entity metrics. Configuration options are provided to choose which method to use. ([#268](https://github.com/CloudDectective-Harmonycloud/kindling/pull/268)) 

--- a/deploy/agent/kindling-deploy.yml
+++ b/deploy/agent/kindling-deploy.yml
@@ -28,8 +28,6 @@ spec:
             memory: 300Mi
         ports:
         - containerPort: 9500
-          hostPort: 9500
-          name: http
           protocol: TCP
         env:
         - name: HOST_PROC

--- a/deploy/agent/kindling-deploy.yml
+++ b/deploy/agent/kindling-deploy.yml
@@ -26,6 +26,11 @@ spec:
             memory: 1Gi
           requests:
             memory: 300Mi
+        ports:
+        - containerPort: 9500
+          hostPort: 9500
+          name: http
+          protocol: TCP
         env:
         - name: HOST_PROC
           value: /host/proc


### PR DESCRIPTION
This is necessary because we want to display the agent in the topology.