### PR TITLE
Fix the bug where the table name of SQL is missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Unreleased 
 ### Enhancements
+- Fix the bug where the table name of SQL is missed. ([#284](https://github.com/CloudDectective-Harmonycloud/kindling/pull/284))
 - Declare the 9500 port in the agent's deployment file ([#282](https://github.com/CloudDectective-Harmonycloud/kindling/pull/282))
 
 ## v0.3.0 - 2022-06-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 
 ## Unreleased 
 ### Enhancements
-- Fix the bug where the table name of SQL is missed. ([#284](https://github.com/CloudDectective-Harmonycloud/kindling/pull/284))
 - Declare the 9500 port in the agent's deployment file ([#282](https://github.com/CloudDectective-Harmonycloud/kindling/pull/282))
+### Bug fixes 
+- Fix the bug where the table name of SQL is missed if there is no trailing character at the end of the table name. ([#284](https://github.com/CloudDectective-Harmonycloud/kindling/pull/284))
 
 ## v0.3.0 - 2022-06-29
 ### New features

--- a/collector/pkg/component/analyzer/network/protocol/mysql/tools/sql_merger.go
+++ b/collector/pkg/component/analyzer/network/protocol/mysql/tools/sql_merger.go
@@ -52,7 +52,7 @@ func (merger SqlMerger) ParseStatement(statement string) string {
 
 func newSqlParser(sqlType string, sqlKey string) SqlParser {
 	patternType := `(?i)(^\s*)` + sqlType + `(.*)`
-	patternKey := `(?i)(?m)` + "(" + sqlKey + ")" + `(\s+(\S*)\s|\n)`
+	patternKey := `(?i)(?m)` + "(" + sqlKey + ")" + `(\s+(\S*)\s*|\n)`
 
 	return SqlParser{
 		regexType: regexp.MustCompile(patternType),

--- a/collector/pkg/component/analyzer/network/protocol/mysql/tools/sql_merger_test.go
+++ b/collector/pkg/component/analyzer/network/protocol/mysql/tools/sql_merger_test.go
@@ -45,6 +45,8 @@ func TestSqlMerger_InsertSql(t *testing.T) {
 			operator: "select",
 			datas: map[string][]string{
 				"select table *": {
+					"select * from table",
+					"select * from table ",
 					"select * from table where id = 1",
 				},
 				"select person *": {

--- a/docs/prometheus_metrics.md
+++ b/docs/prometheus_metrics.md
@@ -51,7 +51,7 @@ Service metrics are generated from the server-side events, which are used to sho
   
 | **Label** | **Example** | **Notes** |
 | --- | --- | --- |
-| `request_content` | select employee | SQL of MySQL. SQL has been truncated to avoid high-cardinality. The format is ['operation' 'space' 'table']. |
+| `request_content` | select employee | SQL of MySQL. SQL has been truncated to avoid high-cardinality. The format is ['operation' 'space' 'table' '*']. |
 | `response_content` | 1064 | Error code of MySQL. Only applicable when the response is in error type. See [codes introduction](https://dev.mysql.com/doc/mysql-errors/5.7/en/error-reference-introduction.html).|
 
 - When protocol is `kafka`:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
We use a regular expression to match the table name in the SQL. There must be a '\s' or a '\n' at the end of the table name before, which means the SQL `select * from student` was seen as `select * from `.

This PR changes the regular expression from `(\s+(\S*)\s|\n)` to `(\s+(\S*)\s*|\n)` to allow no trailing characters.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
Fix #266.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
=== RUN   TestSqlMerger_InsertSql
=== RUN   TestSqlMerger_InsertSql/insert
=== RUN   TestSqlMerger_InsertSql/create
=== RUN   TestSqlMerger_InsertSql/select
=== RUN   TestSqlMerger_InsertSql/delete
--- PASS: TestSqlMerger_InsertSql (0.00s)
    --- PASS: TestSqlMerger_InsertSql/insert (0.00s)
    --- PASS: TestSqlMerger_InsertSql/create (0.00s)
    --- PASS: TestSqlMerger_InsertSql/select (0.00s)
    --- PASS: TestSqlMerger_InsertSql/delete (0.00s)
PASS
ok      github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network/protocol/mysql/tools      0.902s
```