### PR TITLE
Allow the collector run in the non-Kubernetes environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## Unreleased 
 ### Enhancements
-- Allow the collector run in the non-Kubernetes environment by setting the option `disable` true under the `k8smetadataprocessor` section. ([#285](https://github.com/CloudDectective-Harmonycloud/kindling/pull/285))
+- Allow the collector run in the non-Kubernetes environment by setting the option `enable` `false` under the `k8smetadataprocessor` section. ([#285](https://github.com/CloudDectective-Harmonycloud/kindling/pull/285))
 - Declare the 9500 port in the agent's deployment file ([#282](https://github.com/CloudDectective-Harmonycloud/kindling/pull/282))
 ### Bug fixes 
 - Fix the bug where the table name of SQL is missed if there is no trailing character at the end of the table name. ([#284](https://github.com/CloudDectective-Harmonycloud/kindling/pull/284))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Unreleased 
 ### Enhancements
+- Allow the collector run in the non-Kubernetes environment by setting the option `disable` true under the `k8smetadataprocessor` section. ([#285](https://github.com/CloudDectective-Harmonycloud/kindling/pull/285))
 - Declare the 9500 port in the agent's deployment file ([#282](https://github.com/CloudDectective-Harmonycloud/kindling/pull/282))
 ### Bug fixes 
 - Fix the bug where the table name of SQL is missed if there is no trailing character at the end of the table name. ([#284](https://github.com/CloudDectective-Harmonycloud/kindling/pull/284))

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -82,9 +82,9 @@ analyzers:
 
 processors:
   k8smetadataprocessor:
-    # Set "disable" true if you want to run the agent in the non-Kubernetes environment.
+    # Set "enable" false if you want to run the agent in the non-Kubernetes environment.
     # Otherwise, the agent will panic if it can't connect to the API-server.
-    disable: false
+    enable: true
     kube_auth_type: kubeConfig
     kube_config_dir: /root/.kube/config
     grace_delete_period: 60

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -82,6 +82,7 @@ analyzers:
 
 processors:
   k8smetadataprocessor:
+    disable: false
     kube_auth_type: kubeConfig
     kube_config_dir: /root/.kube/config
     grace_delete_period: 60

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -82,6 +82,8 @@ analyzers:
 
 processors:
   k8smetadataprocessor:
+    # Set "disable" true if you want to run the agent in the non-Kubernetes environment.
+    # Otherwise, the agent will panic if it can't connect to the API-server.
     disable: false
     kube_auth_type: kubeConfig
     kube_config_dir: /root/.kube/config

--- a/collector/pkg/component/consumer/processor/k8sprocessor/config.go
+++ b/collector/pkg/component/consumer/processor/k8sprocessor/config.go
@@ -11,14 +11,14 @@ type Config struct {
 	// The unit is seconds, and the default value is 60 seconds.
 	// Should not be lower than 30 seconds.
 	GraceDeletePeriod int `mapstructure:"grace_delete_period"`
-	// Set "Disable" true if you want to run the agent in the non-Kubernetes environment.
+	// Set "Enable" false if you want to run the agent in the non-Kubernetes environment.
 	// Otherwise, the agent will panic if it can't connect to the API-server.
-	Disable bool `mapstructure:"disable"`
+	Enable bool `mapstructure:"enable"`
 }
 
 var DefaultConfig Config = Config{
 	KubeAuthType:      "serviceAccount",
 	KubeConfigDir:     "~/.kube/config",
 	GraceDeletePeriod: 60,
-	Disable:           false,
+	Enable:            true,
 }

--- a/collector/pkg/component/consumer/processor/k8sprocessor/config.go
+++ b/collector/pkg/component/consumer/processor/k8sprocessor/config.go
@@ -11,10 +11,13 @@ type Config struct {
 	// The unit is seconds, and the default value is 60 seconds.
 	// Should not be lower than 30 seconds.
 	GraceDeletePeriod int `mapstructure:"grace_delete_period"`
+	// Disable is used when the agent runs at the non-Kubernetes environment.
+	Disable bool
 }
 
 var DefaultConfig Config = Config{
 	KubeAuthType:      "serviceAccount",
 	KubeConfigDir:     "~/.kube/config",
 	GraceDeletePeriod: 60,
+	Disable:           false,
 }

--- a/collector/pkg/component/consumer/processor/k8sprocessor/config.go
+++ b/collector/pkg/component/consumer/processor/k8sprocessor/config.go
@@ -11,7 +11,8 @@ type Config struct {
 	// The unit is seconds, and the default value is 60 seconds.
 	// Should not be lower than 30 seconds.
 	GraceDeletePeriod int `mapstructure:"grace_delete_period"`
-	// Disable is used when the agent runs at the non-Kubernetes environment.
+	// Set "Disable" true if you want to run the agent in the non-Kubernetes environment.
+	// Otherwise, the agent will panic if it can't connect to the API-server.
 	Disable bool `mapstructure:"disable"`
 }
 

--- a/collector/pkg/component/consumer/processor/k8sprocessor/config.go
+++ b/collector/pkg/component/consumer/processor/k8sprocessor/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	// Should not be lower than 30 seconds.
 	GraceDeletePeriod int `mapstructure:"grace_delete_period"`
 	// Disable is used when the agent runs at the non-Kubernetes environment.
-	Disable bool
+	Disable bool `mapstructure:"disable"`
 }
 
 var DefaultConfig Config = Config{

--- a/collector/pkg/component/consumer/processor/k8sprocessor/kubernetes_processor.go
+++ b/collector/pkg/component/consumer/processor/k8sprocessor/kubernetes_processor.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"github.com/Kindling-project/kindling/collector/pkg/component/consumer"
 	"github.com/Kindling-project/kindling/collector/pkg/component/consumer/processor"
-	kubernetes2 "github.com/Kindling-project/kindling/collector/pkg/metadata/kubernetes"
+	"github.com/Kindling-project/kindling/collector/pkg/metadata/kubernetes"
 	"github.com/Kindling-project/kindling/collector/pkg/model"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constnames"
@@ -19,7 +19,7 @@ const (
 )
 
 type K8sMetadataProcessor struct {
-	metadata      *kubernetes2.K8sMetaDataCache
+	metadata      *kubernetes.K8sMetaDataCache
 	nextConsumer  consumer.Consumer
 	localNodeIp   string
 	localNodeName string
@@ -31,11 +31,11 @@ func NewKubernetesProcessor(cfg interface{}, telemetry *component.TelemetryTools
 	if !ok {
 		telemetry.Logger.Panic("Cannot convert Component config", zap.String("componentType", K8sMetadata))
 	}
-	var options []kubernetes2.Option
-	options = append(options, kubernetes2.WithAuthType(config.KubeAuthType))
-	options = append(options, kubernetes2.WithKubeConfigDir(config.KubeConfigDir))
-	options = append(options, kubernetes2.WithGraceDeletePeriod(config.GraceDeletePeriod))
-	err := kubernetes2.InitK8sHandler(options...)
+	var options []kubernetes.Option
+	options = append(options, kubernetes.WithAuthType(config.KubeAuthType))
+	options = append(options, kubernetes.WithKubeConfigDir(config.KubeConfigDir))
+	options = append(options, kubernetes.WithGraceDeletePeriod(config.GraceDeletePeriod))
+	err := kubernetes.InitK8sHandler(options...)
 	if err != nil {
 		telemetry.Logger.Sugar().Panicf("Failed to initialize [%s]: %v", K8sMetadata, err)
 		return nil
@@ -49,7 +49,7 @@ func NewKubernetesProcessor(cfg interface{}, telemetry *component.TelemetryTools
 		telemetry.Logger.Warn("Local NodeName can not found", zap.Error(err))
 	}
 	return &K8sMetadataProcessor{
-		metadata:      kubernetes2.MetaDataCache,
+		metadata:      kubernetes.MetaDataCache,
 		nextConsumer:  nextConsumer,
 		localNodeIp:   localNodeIp,
 		localNodeName: localNodeName,
@@ -324,13 +324,13 @@ func (p *K8sMetadataProcessor) addK8sMetaDataViaIpDST(labelMap *model.AttributeM
 	}
 }
 
-func addContainerMetaInfoLabelSRC(labelMap *model.AttributeMap, containerInfo *kubernetes2.K8sContainerInfo) {
+func addContainerMetaInfoLabelSRC(labelMap *model.AttributeMap, containerInfo *kubernetes.K8sContainerInfo) {
 	labelMap.UpdateAddStringValue(constlabels.SrcContainer, containerInfo.Name)
 	labelMap.UpdateAddStringValue(constlabels.SrcContainerId, containerInfo.ContainerId)
 	addPodMetaInfoLabelSRC(labelMap, containerInfo.RefPodInfo)
 }
 
-func addPodMetaInfoLabelSRC(labelMap *model.AttributeMap, podInfo *kubernetes2.K8sPodInfo) {
+func addPodMetaInfoLabelSRC(labelMap *model.AttributeMap, podInfo *kubernetes.K8sPodInfo) {
 	labelMap.UpdateAddStringValue(constlabels.SrcNode, podInfo.NodeName)
 	labelMap.UpdateAddStringValue(constlabels.SrcNodeIp, podInfo.NodeAddress)
 	labelMap.UpdateAddStringValue(constlabels.SrcNamespace, podInfo.Namespace)
@@ -343,13 +343,13 @@ func addPodMetaInfoLabelSRC(labelMap *model.AttributeMap, podInfo *kubernetes2.K
 	}
 }
 
-func addContainerMetaInfoLabelDST(labelMap *model.AttributeMap, containerInfo *kubernetes2.K8sContainerInfo) {
+func addContainerMetaInfoLabelDST(labelMap *model.AttributeMap, containerInfo *kubernetes.K8sContainerInfo) {
 	labelMap.UpdateAddStringValue(constlabels.DstContainer, containerInfo.Name)
 	labelMap.UpdateAddStringValue(constlabels.DstContainerId, containerInfo.ContainerId)
 	addPodMetaInfoLabelDST(labelMap, containerInfo.RefPodInfo)
 }
 
-func addPodMetaInfoLabelDST(labelMap *model.AttributeMap, podInfo *kubernetes2.K8sPodInfo) {
+func addPodMetaInfoLabelDST(labelMap *model.AttributeMap, podInfo *kubernetes.K8sPodInfo) {
 	labelMap.UpdateAddStringValue(constlabels.DstNode, podInfo.NodeName)
 	labelMap.UpdateAddStringValue(constlabels.DstNodeIp, podInfo.NodeAddress)
 	labelMap.UpdateAddStringValue(constlabels.DstNamespace, podInfo.Namespace)

--- a/collector/pkg/component/consumer/processor/k8sprocessor/kubernetes_processor.go
+++ b/collector/pkg/component/consumer/processor/k8sprocessor/kubernetes_processor.go
@@ -32,7 +32,7 @@ func NewKubernetesProcessor(cfg interface{}, telemetry *component.TelemetryTools
 	if !ok {
 		telemetry.Logger.Panic("Cannot convert Component config", zap.String("componentType", K8sMetadata))
 	}
-	if config.Disable {
+	if !config.Enable {
 		telemetry.Logger.Info("The kubernetes processor is disabled by the configuration. Won't connect to the API-server and no Kubernetes metadata will be fetched.")
 		return &K8sMetadataProcessor{
 			config:       config,
@@ -47,7 +47,7 @@ func NewKubernetesProcessor(cfg interface{}, telemetry *component.TelemetryTools
 	options = append(options, kubernetes.WithGraceDeletePeriod(config.GraceDeletePeriod))
 	err := kubernetes.InitK8sHandler(options...)
 	if err != nil {
-		telemetry.Logger.Sugar().Panicf("Failed to initialize [%s]: %v", K8sMetadata, err)
+		telemetry.Logger.Sugar().Panicf("Failed to initialize [%s]: %v. Set the option 'enable' false if you want to run the agent in the non-Kubernetes environment.", K8sMetadata, err)
 		return nil
 	}
 
@@ -69,7 +69,7 @@ func NewKubernetesProcessor(cfg interface{}, telemetry *component.TelemetryTools
 }
 
 func (p *K8sMetadataProcessor) Consume(dataGroup *model.DataGroup) error {
-	if p.config.Disable {
+	if !p.config.Enable {
 		return p.nextConsumer.Consume(dataGroup)
 	}
 	name := dataGroup.Name

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -82,6 +82,8 @@ analyzers:
 
 processors:
   k8smetadataprocessor:
+    # Set "disable" true if you want to run the agent in the non-Kubernetes environment.
+    # Otherwise, the agent will panic if it can't connect to the API-server.
     disable: false
     kube_auth_type: serviceAccount
     kube_config_dir: /root/.kube/config

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -82,6 +82,7 @@ analyzers:
 
 processors:
   k8smetadataprocessor:
+    disable: false
     kube_auth_type: serviceAccount
     kube_config_dir: /root/.kube/config
     grace_delete_period: 60

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -82,9 +82,9 @@ analyzers:
 
 processors:
   k8smetadataprocessor:
-    # Set "disable" true if you want to run the agent in the non-Kubernetes environment.
+    # Set "enable" false if you want to run the agent in the non-Kubernetes environment.
     # Otherwise, the agent will panic if it can't connect to the API-server.
-    disable: false
+    enable: true
     kube_auth_type: serviceAccount
     kube_config_dir: /root/.kube/config
     grace_delete_period: 60


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add a `disable` option, which is `false` by default, to the configuration of the `kubernetesprocessor`. If it is true, the `kubernetesprocessor` won't try to connect to the Kubernetes API-server and will just send the `dataGroups` it consumes to the next consumer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some users want to run the collector in the non-Kubernetes environment.

There is also another implementation that meets the requirement. If the `kubernetesprocessor` fails to connect the API-server when initializing, we don't panic the process and just send the data to the next consumer later. In this way, no option is added. But the problem is that the users don't know whether the connection is ok. By explicitly setting the `disable` option, the users know the behavior of the processor. So I prefer panicking the process to letting it run if the connection failed and the option is not set, in which way the users could know exactly what happened.
