### PR TITLE
The exit event in the syscall will carry the event latency

### DIFF
--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -248,6 +248,14 @@ int getEvent(void **pp_kindling_event)
 	}
 
 	uint16_t userAttNumber = 0;
+	uint16_t source = get_kindling_source(ev->get_type());
+	if(source == SYSCALL_EXIT) {
+		strcpy(p_kindling_event->userAttributes[userAttNumber].key, "latency");
+		memcpy(p_kindling_event->userAttributes[userAttNumber].value, to_string(threadInfo->m_latency).data(), 8);
+		p_kindling_event->userAttributes[userAttNumber].valueType = UINT64;
+		p_kindling_event->userAttributes[userAttNumber].len = 8;
+	}
+	userAttNumber++;
 	switch(ev->get_type())
 	{
 	case PPME_TCP_RCV_ESTABLISHED_E:
@@ -493,5 +501,56 @@ uint16_t get_kindling_category(sinsp_evt *sEvt)
 	}
 	default:
 		return CAT_OTHER;
+	}
+}
+
+uint16_t get_kindling_source(uint16_t etype) {
+	if (PPME_IS_ENTER(etype)) {
+		switch (etype) {
+			case PPME_PROCEXIT_E:
+			case PPME_SCHEDSWITCH_6_E:
+			case PPME_SYSDIGEVENT_E:
+			case PPME_CONTAINER_E:
+			case PPME_PROCINFO_E:
+			case PPME_SCHEDSWITCH_1_E:
+			case PPME_DROP_E:
+			case PPME_PROCEXIT_1_E:
+			case PPME_CPU_HOTPLUG_E:
+			case PPME_K8S_E:
+			case PPME_TRACER_E:
+			case PPME_MESOS_E:
+			case PPME_CONTAINER_JSON_E:
+			case PPME_NOTIFICATION_E:
+			case PPME_INFRASTRUCTURE_EVENT_E:
+			case PPME_PAGE_FAULT_E:
+				return SOURCE_UNKNOWN;
+			case PPME_TCP_RCV_ESTABLISHED_E:
+			case PPME_TCP_CLOSE_E:
+			case PPME_TCP_DROP_E:
+			case PPME_TCP_RETRANCESMIT_SKB_E:
+				return KRPOBE;
+				// TODO add cases of tracepoint, kprobe, uprobe
+			default:
+				return SYSCALL_ENTER;
+		}
+	} else {
+		switch (etype) {
+			case PPME_CONTAINER_X:
+			case PPME_PROCINFO_X:
+			case PPME_SCHEDSWITCH_1_X:
+			case PPME_DROP_X:
+			case PPME_CPU_HOTPLUG_X:
+			case PPME_K8S_X:
+			case PPME_TRACER_X:
+			case PPME_MESOS_X:
+			case PPME_CONTAINER_JSON_X:
+			case PPME_NOTIFICATION_X:
+			case PPME_INFRASTRUCTURE_EVENT_X:
+			case PPME_PAGE_FAULT_X:
+				return SOURCE_UNKNOWN;
+				// TODO add cases of tracepoint, kprobe, uprobe
+			default:
+				return SYSCALL_EXIT;
+		}
 	}
 }

--- a/probe/src/cgo/kindling.h
+++ b/probe/src/cgo/kindling.h
@@ -13,6 +13,8 @@ void init_sub_label();
 void sub_event(char* eventName, char* category);
 uint16_t get_protocol(scap_l4_proto proto);
 uint16_t get_type(ppm_param_type type);
+uint16_t get_kindling_source(uint16_t etype);
+
 struct event {
     string event_name;
     ppm_event_type event_type;
@@ -73,6 +75,18 @@ enum Category {
     CAT_SYSTEM = 13, // System-related operations (e.g. reboot)
     Category_MAX = 14
 };
+
+enum Source {
+	SOURCE_UNKNOWN = 0,
+	SYSCALL_ENTER = 1,
+	SYSCALL_EXIT = 2,
+	TRACEPOINT = 3,
+	KRPOBE = 4,
+	KRETPROBE = 5,
+	UPROBE = 6,
+	URETPROBE = 7
+};
+
 const static event kindling_to_sysdig[PPM_EVENT_MAX] = {
 	{"syscall_enter-open",              PPME_SYSCALL_OPEN_E},
 	{"syscall_exit-open",               PPME_SYSCALL_OPEN_X},


### PR DESCRIPTION
Signed-off-by: jundizhou <jundizhou@harmonycloud.cn>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->