### PR TITLE
fix: correct external topology metric name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add a new environment variable: IS_PRINT_EVENT. When the value is true, sinsp events can be printed to the stdout. ([#283](https://github.com/CloudDectective-Harmonycloud/kindling/pull/283))
 - Declare the 9500 port in the agent's deployment file ([#282](https://github.com/CloudDectective-Harmonycloud/kindling/pull/282))
 ### Bug fixes 
+- Fix the bug that the external topologys' metric name is named with `kindling_entity_request` prefix.Change the prefix of these metrics to `kindling_topology_request` ([#287](https://github.com/CloudDectective-Harmonycloud/kindling/pull/287))
 - Fix the bug where the table name of SQL is missed if there is no trailing character at the end of the table name. ([#284](https://github.com/CloudDectective-Harmonycloud/kindling/pull/284))
 
 ## v0.3.0 - 2022-06-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add a new environment variable: IS_PRINT_EVENT. When the value is true, sinsp events can be printed to the stdout. ([#283](https://github.com/CloudDectective-Harmonycloud/kindling/pull/283))
 - Declare the 9500 port in the agent's deployment file ([#282](https://github.com/CloudDectective-Harmonycloud/kindling/pull/282))
 ### Bug fixes 
-- Fix the bug that the external topologys' metric name is named with `kindling_entity_request` prefix.Change the prefix of these metrics to `kindling_topology_request` ([#287](https://github.com/CloudDectective-Harmonycloud/kindling/pull/287))
+- Fix the bug that the external topologys' metric name is named with `kindling_entity_request` prefix. Change the prefix of these metrics to `kindling_topology_request` ([#287](https://github.com/CloudDectective-Harmonycloud/kindling/pull/287))
 - Fix the bug where the table name of SQL is missed if there is no trailing character at the end of the table name. ([#284](https://github.com/CloudDectective-Harmonycloud/kindling/pull/284))
 
 ## v0.3.0 - 2022-06-29

--- a/collector/pkg/component/consumer/exporter/tools/adapter/net_adapter.go
+++ b/collector/pkg/component/consumer/exporter/tools/adapter/net_adapter.go
@@ -56,7 +56,7 @@ func (n *NetMetricGroupAdapter) dealWithPreAggMetricGroups(dataGroup *model.Data
 	srcNamespace := dataGroup.Labels.GetStringValue(constlabels.SrcNamespace)
 	if n.StoreExternalSrcIP && srcNamespace == constlabels.ExternalClusterNamespace && isServer {
 		externalAdapterCache := n.detailTopologyAdapter
-		externalTopology := n.createNetMetricResults(dataGroup, externalAdapterCache, attrType)
+		externalTopology := n.createNetMetricResults(dataGroup, externalAdapterCache, attrType, true)
 		results = append(results, externalTopology...)
 	}
 
@@ -74,20 +74,20 @@ func (n *NetMetricGroupAdapter) dealWithPreAggMetricGroups(dataGroup *model.Data
 			metricAdapterCache = n.aggTopologyAdapter
 		}
 	}
-	metrics := n.createNetMetricResults(dataGroup, metricAdapterCache, attrType)
+	metrics := n.createNetMetricResults(dataGroup, metricAdapterCache, attrType, false)
 	return append(results, metrics...)
 }
 
-func (n *NetMetricGroupAdapter) createNetMetricResults(dataGroup *model.DataGroup, adapter [2]*LabelConverter, attrType AttrType) (tmpResults []*AdaptedResult) {
+func (n *NetMetricGroupAdapter) createNetMetricResults(dataGroup *model.DataGroup, adapter [2]*LabelConverter, attrType AttrType, toTopology bool) (tmpResults []*AdaptedResult) {
 	values := dataGroup.Metrics
 	isServer := dataGroup.Labels.GetBoolValue(constlabels.IsServer)
 	metricsExceptRequestCount := make([]*model.Metric, 0, len(values))
 	requestCount := make([]*model.Metric, 0, 1)
 	for _, metric := range dataGroup.Metrics {
 		if metric.Name != constvalues.RequestCount {
-			metricsExceptRequestCount = append(metricsExceptRequestCount, model.NewMetric(constnames.ToKindlingNetMetricName(metric.Name, isServer), metric.GetData()))
+			metricsExceptRequestCount = append(metricsExceptRequestCount, model.NewMetric(constnames.ToKindlingNetMetricName(metric.Name, isServer && !toTopology), metric.GetData()))
 		} else {
-			requestCount = append(requestCount, model.NewMetric(constnames.ToKindlingNetMetricName(metric.Name, isServer), metric.GetData()))
+			requestCount = append(requestCount, model.NewMetric(constnames.ToKindlingNetMetricName(metric.Name, isServer && !toTopology), metric.GetData()))
 		}
 	}
 	tmpResults = make([]*AdaptedResult, 0, 2)


### PR DESCRIPTION
We used `kindling_entity_request`  to name those request metrics captured from the server-side which shows the working status of the service, the key to identifying server-side metrics is a label named 'is_server'. 

That makes a mistake when we are trying to use server-side metrics to show topology from outside the cluster.

The generated topology should be named with the prefix `kindling_topology_request`, but now they are named with the prefix `kindling_entity_request` since the  'is_server' label is true.

This PR will fix this.