### PR TITLE
Print logs when subscribing to events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 .idea/
+.vscode/
+
+build/
+probe/src/probe/cmake-build-debug/
+probe/build/
+
+*.log
+logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Unreleased 
 ### Enhancements
+- Print logs when subscribing to events. Print a warning message if there is no event the agent subscribes to. ([#290](https://github.com/CloudDectective-Harmonycloud/kindling/pull/290))
 - Allow the collector run in the non-Kubernetes environment by setting the option `enable` `false` under the `k8smetadataprocessor` section. ([#285](https://github.com/CloudDectective-Harmonycloud/kindling/pull/285))
 - Add a new environment variable: IS_PRINT_EVENT. When the value is true, sinsp events can be printed to the stdout. ([#283](https://github.com/CloudDectective-Harmonycloud/kindling/pull/283))
 - Declare the 9500 port in the agent's deployment file ([#282](https://github.com/CloudDectective-Harmonycloud/kindling/pull/282))

--- a/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
+++ b/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
@@ -171,6 +171,11 @@ func (r *CgoReceiver) sendToNextConsumer(evt *model.KindlingEvent) error {
 }
 
 func (r *CgoReceiver) subEvent() {
+	if len(r.cfg.SubscribeInfo) == 0 {
+		r.telemetry.Logger.Warn("No events are subscribed by cgoreceiver. Please check your configuration.")
+	} else {
+		r.telemetry.Logger.Sugar().Infof("The subscribed events are: %v", r.cfg.SubscribeInfo)
+	}
 	for _, value := range r.cfg.SubscribeInfo {
 		C.subEventForGo(C.CString(value.Name), C.CString(value.Category))
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
1. Print logs when subscribing to events. Print a warning message if there is no event the agent subscribes to.
2. Add items to `.gitignore`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some users forgot to modify the configuration to subscribe to events after upgrading Kindling to v0.3.0, which caused no event to be received by Kindling. As no logs are printed, it is hard for troubleshooting.