### PR TITLE
enhance/improve log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Unreleased 
 ### Enhancements
+- Optimize the log output. ([#299](https://github.com/CloudDectective-Harmonycloud/kindling/pull/299))
 - Print logs when subscribing to events. Print a warning message if there is no event the agent subscribes to. ([#290](https://github.com/CloudDectective-Harmonycloud/kindling/pull/290))
 - Allow the collector run in the non-Kubernetes environment by setting the option `enable` `false` under the `k8smetadataprocessor` section. ([#285](https://github.com/CloudDectective-Harmonycloud/kindling/pull/285))
 - Add a new environment variable: IS_PRINT_EVENT. When the value is true, sinsp events can be printed to the stdout. ([#283](https://github.com/CloudDectective-Harmonycloud/kindling/pull/283))

--- a/collector/pkg/component/analyzer/loganalyzer/loganalyzer.go
+++ b/collector/pkg/component/analyzer/loganalyzer/loganalyzer.go
@@ -5,7 +5,6 @@ import (
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer"
 	"github.com/Kindling-project/kindling/collector/pkg/component/consumer"
 	"github.com/Kindling-project/kindling/collector/pkg/model"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -34,10 +33,8 @@ func (a *LogAnalyzer) Start() error {
 }
 
 func (a *LogAnalyzer) ConsumeEvent(event *model.KindlingEvent) error {
-	if ce := a.telemetry.Logger.Check(zapcore.InfoLevel, "Receive event"); ce != nil {
-		ce.Write(
-			zap.String("event", event.String()),
-		)
+	if ce := a.telemetry.Logger.Check(zapcore.InfoLevel, ""); ce != nil {
+		a.telemetry.Logger.Debug("Receive event: " + event.String())
 	}
 	for _, nextConsumer := range a.nextConsumers {
 		nextConsumer.Consume(&model.DataGroup{})

--- a/collector/pkg/component/analyzer/loganalyzer/loganalyzer.go
+++ b/collector/pkg/component/analyzer/loganalyzer/loganalyzer.go
@@ -1,6 +1,8 @@
 package loganalyzer
 
 import (
+	"fmt"
+
 	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer"
 	"github.com/Kindling-project/kindling/collector/pkg/component/consumer"
@@ -34,7 +36,7 @@ func (a *LogAnalyzer) Start() error {
 
 func (a *LogAnalyzer) ConsumeEvent(event *model.KindlingEvent) error {
 	if ce := a.telemetry.Logger.Check(zapcore.InfoLevel, ""); ce != nil {
-		a.telemetry.Logger.Debug("Receive event: " + event.String())
+		a.telemetry.Logger.Debug(fmt.Sprintf("Receive event: %+v", event))
 	}
 	for _, nextConsumer := range a.nextConsumers {
 		nextConsumer.Consume(&model.DataGroup{})

--- a/collector/pkg/component/analyzer/network/network_analyzer.go
+++ b/collector/pkg/component/analyzer/network/network_analyzer.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Kindling-project/kindling/collector/pkg/model/constnames"
 	"go.opentelemetry.io/otel/attribute"
 
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/Kindling-project/kindling/collector/pkg/model"
@@ -319,10 +318,8 @@ func (na *NetworkAnalyzer) distributeTraceMetric(oldPairs *messagePairs, newPair
 	// Case 3 Normal             Connect/Request/Response   Request/Response
 	records := na.parseProtocols(oldPairs)
 	for _, record := range records {
-		if ce := na.telemetry.Logger.Check(zapcore.DebugLevel, "NetworkAnalyzer To NextProcess: "); ce != nil {
-			ce.Write(
-				zap.String("record", record.String()),
-			)
+		if ce := na.telemetry.Logger.Check(zapcore.DebugLevel, ""); ce != nil {
+			na.telemetry.Logger.Debug("NetworkAnalyzer To NextProcess:\n" + record.String())
 		}
 		netanalyzerParsedRequestTotal.Add(context.Background(), 1, attribute.String("protocol", record.Labels.GetStringValue(constlabels.Protocol)))
 		for _, nexConsumer := range na.nextConsumers {

--- a/collector/pkg/component/consumer/exporter/logexporter/logexporter.go
+++ b/collector/pkg/component/consumer/exporter/logexporter/logexporter.go
@@ -4,7 +4,6 @@ import (
 	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"github.com/Kindling-project/kindling/collector/pkg/component/consumer/exporter"
 	"github.com/Kindling-project/kindling/collector/pkg/model"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -22,9 +21,7 @@ func New(config interface{}, telemetry *component.TelemetryTools) exporter.Expor
 
 func (e *LogExporter) Consume(dataGroup *model.DataGroup) error {
 	if ce := e.telemetry.Logger.Check(zapcore.DebugLevel, "Receiver DataGroup"); ce != nil {
-		ce.Write(
-			zap.String("dataGroup", dataGroup.String()),
-		)
+		e.telemetry.Logger.Debug("Receiver DataGroup:\n " + dataGroup.String())
 	}
 	return nil
 }

--- a/collector/pkg/component/consumer/exporter/otelexporter/consume.go
+++ b/collector/pkg/component/consumer/exporter/otelexporter/consume.go
@@ -21,10 +21,8 @@ func (e *OtelExporter) Consume(dataGroup *model.DataGroup) error {
 	}
 
 	dataGroupReceiverCounter.Add(context.Background(), 1, attribute.String("name", dataGroup.Name))
-	if ce := e.telemetry.Logger.Check(zap.DebugLevel, "exporter receives a dataGroup: "); ce != nil {
-		ce.Write(
-			zap.String("dataGroup", dataGroup.String()),
-		)
+	if ce := e.telemetry.Logger.Check(zap.DebugLevel, ""); ce != nil {
+		e.telemetry.Logger.Debug("exporter receives a dataGroup: \n" + dataGroup.String())
 	}
 
 	for i := 0; i < len(e.adapters); i++ {

--- a/collector/pkg/component/consumer/exporter/prometheusexporter/consume.go
+++ b/collector/pkg/component/consumer/exporter/prometheusexporter/consume.go
@@ -11,10 +11,8 @@ func (p *prometheusExporter) Consume(dataGroup *model.DataGroup) error {
 		// no need consume
 		return nil
 	}
-	if ce := p.telemetry.Logger.Check(zap.DebugLevel, "exporter receives a dataGroup: "); ce != nil {
-		ce.Write(
-			zap.String("dataGroup", dataGroup.String()),
-		)
+	if ce := p.telemetry.Logger.Check(zap.DebugLevel, ""); ce != nil {
+		p.telemetry.Logger.Debug("exporter receives a dataGroup: " + dataGroup.String())
 	}
 
 	if adapters, ok := p.adapters[dataGroup.Name]; ok {

--- a/collector/pkg/component/consumer/exporter/prometheusexporter/consume.go
+++ b/collector/pkg/component/consumer/exporter/prometheusexporter/consume.go
@@ -12,7 +12,7 @@ func (p *prometheusExporter) Consume(dataGroup *model.DataGroup) error {
 		return nil
 	}
 	if ce := p.telemetry.Logger.Check(zap.DebugLevel, ""); ce != nil {
-		p.telemetry.Logger.Debug("exporter receives a dataGroup: " + dataGroup.String())
+		p.telemetry.Logger.Debug("exporter receives a dataGroup:\n" + dataGroup.String())
 	}
 
 	if adapters, ok := p.adapters[dataGroup.Name]; ok {

--- a/collector/pkg/component/consumer/processor/nodemetricprocessor/node_metric_processor.go
+++ b/collector/pkg/component/consumer/processor/nodemetricprocessor/node_metric_processor.go
@@ -59,10 +59,8 @@ func (p *NodeMetricProcessor) process(dataGroup *model.DataGroup, role string) e
 	dstNodeIp := labels.GetStringValue(constlabels.DstNodeIp)
 	srcNodeIp := labels.GetStringValue(constlabels.SrcNodeIp)
 	if dstNodeIp == "" || srcNodeIp == "" {
-		if ce := p.telemetry.Logger.Check(zapcore.DebugLevel, "dstNodeIp or srcNodeIp is empty which is not expected, skip: "); ce != nil {
-			ce.Write(
-				zap.String("dataGroup", dataGroup.String()),
-			)
+		if ce := p.telemetry.Logger.Check(zapcore.DebugLevel, ""); ce != nil {
+			p.telemetry.Logger.Debug("dstNodeIp or srcNodeIp is empty which is not expected, skip:\n" + dataGroup.String())
 		}
 		return nil
 	}

--- a/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
+++ b/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
@@ -10,6 +10,7 @@ package cgoreceiver
 */
 import "C"
 import (
+	"fmt"
 	"sync"
 	"time"
 	"unsafe"
@@ -152,7 +153,7 @@ func If(condition bool, trueVal, falseVal interface{}) interface{} {
 
 func (r *CgoReceiver) sendToNextConsumer(evt *model.KindlingEvent) error {
 	if ce := r.telemetry.Logger.Check(zapcore.DebugLevel, ""); ce != nil {
-		r.telemetry.Logger.Debug("Receive Event: " + evt.String())
+		r.telemetry.Logger.Debug(fmt.Sprintf("Receive Event: %+v", evt))
 	}
 	analyzers := r.analyzerManager.GetConsumableAnalyzers(evt.Name)
 	if analyzers == nil || len(analyzers) == 0 {

--- a/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
+++ b/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
@@ -151,10 +151,8 @@ func If(condition bool, trueVal, falseVal interface{}) interface{} {
 }
 
 func (r *CgoReceiver) sendToNextConsumer(evt *model.KindlingEvent) error {
-	if ce := r.telemetry.Logger.Check(zapcore.DebugLevel, "Receive Event"); ce != nil {
-		ce.Write(
-			zap.String("event", evt.String()),
-		)
+	if ce := r.telemetry.Logger.Check(zapcore.DebugLevel, ""); ce != nil {
+		r.telemetry.Logger.Debug("Receive Event: " + evt.String())
 	}
 	analyzers := r.analyzerManager.GetConsumableAnalyzers(evt.Name)
 	if analyzers == nil || len(analyzers) == 0 {

--- a/collector/pkg/model/attribute_map.go
+++ b/collector/pkg/model/attribute_map.go
@@ -17,6 +17,14 @@ type AttributeMap struct {
 	values map[string]AttributeValue
 }
 
+func (a AttributeMap) MarshalJSON() ([]byte, error) {
+	return json.Marshal(a.values)
+}
+
+func (a AttributeMap) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &a.values)
+}
+
 func NewAttributeMap() *AttributeMap {
 	values := make(map[string]AttributeValue)
 	return &AttributeMap{values}
@@ -175,6 +183,14 @@ func (v *stringValue) Type() AttributeValueType {
 	return StringAttributeValueType
 }
 
+func (v stringValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *stringValue) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.value)
+}
+
 func (v *stringValue) ToString() string {
 	return v.value
 }
@@ -195,6 +211,14 @@ func (v *intValue) ToString() string {
 	return strconv.FormatInt(v.value, 10)
 }
 
+func (v intValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *intValue) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.value)
+}
+
 func (v *intValue) Reset() {
 	v.value = 0
 }
@@ -209,6 +233,14 @@ func (v *boolValue) Type() AttributeValueType {
 
 func (v *boolValue) ToString() string {
 	return strconv.FormatBool(v.value)
+}
+
+func (v boolValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.value)
+}
+
+func (v *boolValue) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.value)
 }
 
 func (v *boolValue) Reset() {

--- a/collector/pkg/model/attribute_map.go
+++ b/collector/pkg/model/attribute_map.go
@@ -21,7 +21,7 @@ func (a AttributeMap) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a.values)
 }
 
-func (a AttributeMap) UnmarshalJSON(data []byte) error {
+func (a *AttributeMap) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &a.values)
 }
 

--- a/collector/pkg/model/data_group.go
+++ b/collector/pkg/model/data_group.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -63,21 +64,25 @@ func (g *DataGroup) RemoveMetric(name string) {
 	g.Metrics = newValues
 }
 
-func (g *DataGroup) String() string {
+func (g DataGroup) String() string {
 	var str strings.Builder
-	str.WriteString(fmt.Sprintf("GagugeGroup:\n"))
+	str.WriteString(fmt.Sprintln("DataGroup:"))
 	str.WriteString(fmt.Sprintf("\tName: %s\n", g.Name))
-	str.WriteString(fmt.Sprintf("\tValues: \n"))
+	str.WriteString(fmt.Sprintln("\tValues:"))
 	for _, v := range g.Metrics {
 		switch v.DataType() {
 		case IntMetricType:
-			str.WriteString(fmt.Sprintf("\t\t{Name: %s, Value: %d}\n", v.Name, v.GetInt().Value))
+			str.WriteString(fmt.Sprintf("\t\t\"%s\": %d\n", v.Name, v.GetInt().Value))
 		case HistogramMetricType:
 			histogram := v.GetHistogram()
-			str.WriteString(fmt.Sprintf("\t\t{Name: %s, Sum: %d, Count: %d,ExplicitBoundaries: %v,BucketCount: %v}\n", v.Name, histogram.Sum, histogram.Count, histogram.ExplicitBoundaries, histogram.BucketCounts))
+			str.WriteString(fmt.Sprintf("\t\t\"%s\": \n\t\t\tSum: %d\n\t\t\tCount: %d\n\t\t\tExplicitBoundaries: %v\n\t\t\tBucketCount: %v\n", v.Name, histogram.Sum, histogram.Count, histogram.ExplicitBoundaries, histogram.BucketCounts))
 		}
 	}
-	str.WriteString(fmt.Sprintf("\tLabels: %v\n", g.Labels))
+	if labelsStr, err := json.MarshalIndent(g.Labels, "\t", "\t"); err == nil {
+		str.WriteString(fmt.Sprintf("\tLabels:\n\t%v\n", string(labelsStr)))
+	} else {
+		str.WriteString(fmt.Sprintln("\tLabels: marshal Failed"))
+	}
 	str.WriteString(fmt.Sprintf("\tTimestamp: %d\n", g.Timestamp))
 	return str.String()
 }

--- a/collector/pkg/model/kindling_event.go
+++ b/collector/pkg/model/kindling_event.go
@@ -1,6 +1,12 @@
 package model
 
-import "encoding/json"
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+var replacer = strings.NewReplacer("\n", "\\n", "\r", "\\r")
 
 type Source int32
 
@@ -236,11 +242,7 @@ var L4Proto_value = map[string]int32{
 	"RAW":     4,
 }
 
-func (m *KindlingEvent) String() string {
-	data, _ := json.Marshal(&m)
-	return string(data)
-}
-
+type UserAttributes [8]KeyValue
 type KindlingEvent struct {
 	Source Source
 	// Timestamp in nanoseconds at which the event were collected.
@@ -252,9 +254,27 @@ type KindlingEvent struct {
 	// Number of UserAttributes
 	ParamsNumber uint16
 	// User-defined Attributions of Kindling Event, now including latency for syscall.
-	UserAttributes [8]KeyValue
+	UserAttributes UserAttributes
 	// Context includes Thread information and Fd information.
 	Ctx Context
+}
+
+func (attrs UserAttributes) String() string {
+	var attrsStr strings.Builder
+	var block = false
+	attrsStr.WriteByte('[')
+	for _, attr := range attrs {
+		if attr.ValueType != ValueType_NONE {
+			if block {
+				attrsStr.WriteByte(' ')
+			} else {
+				block = true
+			}
+			attrsStr.WriteString(fmt.Sprint(attr))
+		}
+	}
+	attrsStr.WriteByte(']')
+	return attrsStr.String()
 }
 
 func (k *KindlingEvent) Reset() {
@@ -291,7 +311,7 @@ func (m *KindlingEvent) GetCategory() Category {
 }
 
 func (m *KindlingEvent) GetUserAttributes() *[8]KeyValue {
-	return &m.UserAttributes
+	return (*[8]KeyValue)(&m.UserAttributes)
 }
 
 func (m *KindlingEvent) GetCtx() *Context {
@@ -305,6 +325,37 @@ type KeyValue struct {
 	ValueType ValueType
 	// Value of Key in bytes, should be converted according to ValueType.
 	Value []byte
+}
+
+func (m KeyValue) String() string {
+	switch m.ValueType {
+	case ValueType_CHARBUF:
+		return fmt.Sprintf("%s:CHARBUF(%s)", m.Key, replacer.Replace(strings.ToValidUTF8(string(m.Value), "")))
+	case ValueType_BYTEBUF:
+		return fmt.Sprintf("%s:BYTEBUF(%s)", m.Key, replacer.Replace(strings.ToValidUTF8(string(m.Value), "")))
+	case ValueType_INT64:
+		fallthrough
+	case ValueType_INT32:
+		fallthrough
+	case ValueType_INT16:
+		fallthrough
+	case ValueType_INT8:
+		return fmt.Sprintf("%s:INT(%d)", m.Key, m.GetIntValue())
+	case ValueType_UINT64:
+		fallthrough
+	case ValueType_UINT32:
+		fallthrough
+	case ValueType_UINT16:
+		fallthrough
+	case ValueType_UINT8:
+		return fmt.Sprintf("%s:UINT(%d)", m.Key, m.GetUintValue())
+	case ValueType_FLOAT:
+		return fmt.Sprintf("%s:FLOAT(%f)", m.Key, math.Float32frombits(byteOrder.Uint32(m.Value)))
+	case ValueType_NONE:
+		return "none"
+	default:
+		return fmt.Sprintf("%s:UNKNOW(%s)", m.Key, string(m.Value))
+	}
 }
 
 func (m *KeyValue) GetKey() string {
@@ -409,6 +460,8 @@ func (m *Thread) GetContainerName() string {
 	return ""
 }
 
+type IP []uint32
+
 type Fd struct {
 	// FD number.
 	Num int32
@@ -421,8 +474,8 @@ type Fd struct {
 	Protocol L4Proto
 	// repeated for ipv6, client_ip[0] for ipv4
 	Role  bool
-	Sip   []uint32
-	Dip   []uint32
+	Sip   IP
+	Dip   IP
 	Sport uint32
 	Dport uint32
 	// if FD is type of unix_sock
@@ -430,6 +483,14 @@ type Fd struct {
 	Source uint64
 	// Destination socket endpoint
 	Destination uint64
+}
+
+func (i IP) String() string {
+	if len(i) > 0 {
+		return IPLong2String(i[0])
+	} else {
+		return ""
+	}
 }
 
 func (m *Fd) GetNum() int32 {

--- a/collector/pkg/model/kindling_event_helper_test.go
+++ b/collector/pkg/model/kindling_event_helper_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +31,8 @@ func TestGetUintUserAttribute(t *testing.T) {
 					{Key: test.key, ValueType: test.valueType, Value: test.value},
 				},
 			}
-			assert.Equal(t, test.expect, event.GetUintUserAttribute(test.key))
+			fmt.Printf("%+v", event)
+			// assert.Equal(t, test.expect, event.GetUintUserAttribute(test.key))
 		})
 	}
 }

--- a/collector/pkg/model/kindling_event_helper_test.go
+++ b/collector/pkg/model/kindling_event_helper_test.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,8 +30,7 @@ func TestGetUintUserAttribute(t *testing.T) {
 					{Key: test.key, ValueType: test.valueType, Value: test.value},
 				},
 			}
-			fmt.Printf("%+v", event)
-			// assert.Equal(t, test.expect, event.GetUintUserAttribute(test.key))
+			assert.Equal(t, test.expect, event.GetUintUserAttribute(test.key))
 		})
 	}
 }


### PR DESCRIPTION
## Description
- overwrite MarshalJSON() and UnmarshalJSON() for attributeMap for those private Members
- move those outputs in JSON from `zap.filed` to message  

## Related Issue
#298 

## After Change
KindlingEvent
```text
2022-07-28T18:35:45.733Z        DEBUG   cgoreceiver/cgoreceiver.go:156  Receive Event: &{Source:SOURCE_UNKNOWN Timestamp:1659033341930367401 Name:connect Category:3 ParamsNumber:3 UserAttributes:[latency:UINT(306428) res:INT(0) tuple:BYTEBUF(^A^Y^^@^Y^/var/run/docker.sock^@)] Ctx:{ThreadInfo:{Pid:11474 Tid:11608 Uid:0 Gid:0 Comm:kubelet ContainerId: ContainerName:} FdInfo:{Num:10 TypeFd:8 Filename: Directory: Protocol:0 Role:false Sip:0.0.0.0 Dip:0.0.0.0 Sport:0 Dport:0 Source:18446622435791445440 Destination:18446622435791437824}}}
```
DataGroup
```text
2022-07-28T18:35:45.741Z        DEBUG   network/network_analyzer.go:322 NetworkAnalyzer To NextProcess:
DataGroup:
        Name: net_request_metric_group
        Values:
                "connect_time": 0
                "request_sent_time": 21010
                "waiting_ttfb_time": 1197746594
                "content_download_time": 656720
                "request_total_time": 1198424324
                "request_io": 35
                "response_io": 10564
        Labels:
        {
                "comm": "kindling-collec",
                "container_id": "c4ffdfa6ebfa",
                "dnat_ip": "10.10.101.124",
                "dnat_port": 6443,
                "dst_ip": "10.96.0.1",
                "dst_port": 443,
                "error_type": 0,
                "is_error": false,
                "is_server": false,
                "is_slow": true,
                "pid": 32433,
                "protocol": "NOSUPPORT",
                "src_ip": "10.10.103.159",
                "src_port": 58178
        }
        Timestamp: 1659033342510904252
```

