### PR TITLE
feature/add filters for the debug level logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add a new environment variable: IS_PRINT_EVENT. When the value is true, sinsp events can be printed to the stdout. ([#283](https://github.com/CloudDectective-Harmonycloud/kindling/pull/283))
 - Declare the 9500 port in the agent's deployment file ([#282](https://github.com/CloudDectective-Harmonycloud/kindling/pull/282))
 ### Bug fixes 
+- Fix the bug that need_trace_as_span options cannot take effect ([#292](https://github.com/CloudDectective-Harmonycloud/kindling/pull/292))
 - Fix connection failure rate data lost when change topology layout in the Grafana plugin. ([#289](https://github.com/CloudDectective-Harmonycloud/kindling/pull/289))
 - Fix the bug that the external topologys' metric name is named with `kindling_entity_request` prefix. Change the prefix of these metrics to `kindling_topology_request` ([#287](https://github.com/CloudDectective-Harmonycloud/kindling/pull/287))
 - Fix the bug where the table name of SQL is missed if there is no trailing character at the end of the table name. ([#284](https://github.com/CloudDectective-Harmonycloud/kindling/pull/284))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## Unreleased 
 ### Enhancements 
-- Improve log readability, and add an option name `debug_selector` to filter debug_log from different components ([#299](https://github.com/CloudDectective-Harmonycloud/kindling/pull/299))
+- Improve log readability, and add an option name `debug_selector` to filter debug_log from different components ([#300](https://github.com/CloudDectective-Harmonycloud/kindling/pull/300))
 - Print logs when subscribing to events. Print a warning message if there is no event the agent subscribes to. ([#290](https://github.com/CloudDectective-Harmonycloud/kindling/pull/290))
 - Allow the collector run in the non-Kubernetes environment by setting the option `enable` `false` under the `k8smetadataprocessor` section. ([#285](https://github.com/CloudDectective-Harmonycloud/kindling/pull/285))
 - Add a new environment variable: IS_PRINT_EVENT. When the value is true, sinsp events can be printed to the stdout. ([#283](https://github.com/CloudDectective-Harmonycloud/kindling/pull/283))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 2. Records in this file are not identical to the title of their Pull Requests. A detailed description is necessary for understanding what changes are and why they are made.
 
 ## Unreleased 
-### Enhancements
+### Enhancements 
+- Improve log readability, and add an option name `debug_selector` to filter debug_log from different components ([#299](https://github.com/CloudDectective-Harmonycloud/kindling/pull/299))
 - Print logs when subscribing to events. Print a warning message if there is no event the agent subscribes to. ([#290](https://github.com/CloudDectective-Harmonycloud/kindling/pull/290))
 - Allow the collector run in the non-Kubernetes environment by setting the option `enable` `false` under the `k8smetadataprocessor` section. ([#285](https://github.com/CloudDectective-Harmonycloud/kindling/pull/285))
 - Add a new environment variable: IS_PRINT_EVENT. When the value is true, sinsp events can be printed to the stdout. ([#283](https://github.com/CloudDectective-Harmonycloud/kindling/pull/283))

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -159,10 +159,10 @@ observability:
   logger:
     console_level: info # debug,info,warn,error,none
     file_level: info
-    # debug_selector is used to filter debug_message from different components
-    # 1. This filter will not take effect when there is no element in debug_selector list
-    # 2. If list is not empty, only component contains in this list will print debug-message
-    # 3. The name of each component is defined above , such as `receiver.cgoreceiver`, `exporter.otelexporter`, only need the second part of config name
+    # debug_selector is used to filter debug message from different components
+    # 1. This filter will not take effect when there is no element in the debug_selector list
+    # 2. If the list is not empty, only the components contained in this list will print debug message
+    # 3. The name of each component is defined above, such as `receiver.cgoreceiver`, `exporter.otelexporter`, only the second part of the config name needed
     # e.g debug_selector: ["cgoreceiver","otelexporter"]
     debug_selector: []
     file_rotation:

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -160,9 +160,9 @@ observability:
     console_level: info # debug,info,warn,error,none
     file_level: info
     # debug_selector is used to filter debug_message from different components
-    # 1. this filter will not take effect when there is no element in debug_selector list
-    # 2. if list is not empty, only component contains in this list will print debug-message
-    # 3. the name of each component is defined above , such as `receiver.cgoreceiver`, `exporter.otelexporter`, only need the second part of config name
+    # 1. This filter will not take effect when there is no element in debug_selector list
+    # 2. If list is not empty, only component contains in this list will print debug-message
+    # 3. The name of each component is defined above , such as `receiver.cgoreceiver`, `exporter.otelexporter`, only need the second part of config name
     # e.g debug_selector: ["cgoreceiver","otelexporter"]
     debug_selector: []
     file_rotation:

--- a/collector/docker/kindling-collector-config.yml
+++ b/collector/docker/kindling-collector-config.yml
@@ -159,6 +159,12 @@ observability:
   logger:
     console_level: info # debug,info,warn,error,none
     file_level: info
+    # debug_selector is used to filter debug_message from different components
+    # 1. this filter will not take effect when there is no element in debug_selector list
+    # 2. if list is not empty, only component contains in this list will print debug-message
+    # 3. the name of each component is defined above , such as `receiver.cgoreceiver`, `exporter.otelexporter`, only need the second part of config name
+    # e.g debug_selector: ["cgoreceiver","otelexporter"]
+    debug_selector: []
     file_rotation:
       filename: agent.log
       maxsize: 512 #MB

--- a/collector/internal/application/application.go
+++ b/collector/internal/application/application.go
@@ -52,7 +52,7 @@ func New() (*Application, error) {
 }
 
 func (a *Application) Run() error {
-	err := a.analyzerManager.StartAll(a.telemetry.Telemetry.Logger)
+	err := a.analyzerManager.StartAll(a.telemetry.Logger)
 	if err != nil {
 		return fmt.Errorf("failed to start application: %v", err)
 	}
@@ -65,7 +65,7 @@ func (a *Application) Run() error {
 }
 
 func (a *Application) Shutdown() error {
-	return multierr.Combine(a.receiver.Shutdown(), a.analyzerManager.ShutdownAll(a.telemetry.Telemetry.Logger))
+	return multierr.Combine(a.receiver.Shutdown(), a.analyzerManager.ShutdownAll(a.telemetry.Logger))
 }
 
 func initFlags() error {
@@ -103,27 +103,27 @@ func (a *Application) buildPipeline() error {
 	// TODO: Build pipeline via configuration to implement dependency injection
 	// Initialize exporters
 	otelExporterFactory := a.componentsFactory.Exporters[otelexporter.Otel]
-	otelExporter := otelExporterFactory.NewFunc(otelExporterFactory.Config, a.telemetry.Telemetry)
+	otelExporter := otelExporterFactory.NewFunc(otelExporterFactory.Config, a.telemetry.GetTelemetryTools(otelexporter.Otel))
 	// Initialize all processors
 	// 1. DataGroup Aggregator
 	aggregateProcessorFactory := a.componentsFactory.Processors[aggregateprocessor.Type]
-	aggregateProcessor := aggregateProcessorFactory.NewFunc(aggregateProcessorFactory.Config, a.telemetry.Telemetry, otelExporter)
+	aggregateProcessor := aggregateProcessorFactory.NewFunc(aggregateProcessorFactory.Config, a.telemetry.GetTelemetryTools(aggregateprocessor.Type), otelExporter)
 	// 2. Kubernetes metadata processor
 	k8sProcessorFactory := a.componentsFactory.Processors[k8sprocessor.K8sMetadata]
-	k8sMetadataProcessor := k8sProcessorFactory.NewFunc(k8sProcessorFactory.Config, a.telemetry.Telemetry, aggregateProcessor)
+	k8sMetadataProcessor := k8sProcessorFactory.NewFunc(k8sProcessorFactory.Config, a.telemetry.GetTelemetryTools(k8sprocessor.K8sMetadata), aggregateProcessor)
 	// Initialize all analyzers
 	// 1. Common network request analyzer
 	networkAnalyzerFactory := a.componentsFactory.Analyzers[network.Network.String()]
 	// Now NetworkAnalyzer must be initialized before any other analyzers, because it will
 	// use its configuration to initialize the conntracker module which is also used by others.
-	networkAnalyzer := networkAnalyzerFactory.NewFunc(networkAnalyzerFactory.Config, a.telemetry.Telemetry, []consumer.Consumer{k8sMetadataProcessor})
+	networkAnalyzer := networkAnalyzerFactory.NewFunc(networkAnalyzerFactory.Config, a.telemetry.GetTelemetryTools(network.Network.String()), []consumer.Consumer{k8sMetadataProcessor})
 	// 2. Layer 4 TCP events analyzer
-	aggregateProcessorForTcp := aggregateProcessorFactory.NewFunc(aggregateProcessorFactory.Config, a.telemetry.Telemetry, otelExporter)
-	k8sMetadataProcessor2 := k8sProcessorFactory.NewFunc(k8sProcessorFactory.Config, a.telemetry.Telemetry, aggregateProcessorForTcp)
+	aggregateProcessorForTcp := aggregateProcessorFactory.NewFunc(aggregateProcessorFactory.Config, a.telemetry.GetTelemetryTools(aggregateprocessor.Type), otelExporter)
+	k8sMetadataProcessor2 := k8sProcessorFactory.NewFunc(k8sProcessorFactory.Config, a.telemetry.GetTelemetryTools(aggregateprocessor.Type), aggregateProcessorForTcp)
 	tcpAnalyzerFactory := a.componentsFactory.Analyzers[tcpmetricanalyzer.TcpMetric.String()]
-	tcpAnalyzer := tcpAnalyzerFactory.NewFunc(tcpAnalyzerFactory.Config, a.telemetry.Telemetry, []consumer.Consumer{k8sMetadataProcessor2})
+	tcpAnalyzer := tcpAnalyzerFactory.NewFunc(tcpAnalyzerFactory.Config, a.telemetry.GetTelemetryTools(tcpconnectanalyzer.Type.String()), []consumer.Consumer{k8sMetadataProcessor2})
 	tcpConnectAnalyzerFactory := a.componentsFactory.Analyzers[tcpconnectanalyzer.Type.String()]
-	tcpConnectAnalyzer := tcpConnectAnalyzerFactory.NewFunc(tcpConnectAnalyzerFactory.Config, a.telemetry.Telemetry, []consumer.Consumer{k8sMetadataProcessor})
+	tcpConnectAnalyzer := tcpConnectAnalyzerFactory.NewFunc(tcpConnectAnalyzerFactory.Config, a.telemetry.GetTelemetryTools(tcpconnectanalyzer.Type.String()), []consumer.Consumer{k8sMetadataProcessor})
 	// Initialize receiver packaged with multiple analyzers
 	analyzerManager, err := analyzer.NewManager(networkAnalyzer, tcpAnalyzer, tcpConnectAnalyzer)
 	if err != nil {
@@ -132,7 +132,7 @@ func (a *Application) buildPipeline() error {
 	a.analyzerManager = analyzerManager
 
 	cgoReceiverFactory := a.componentsFactory.Receivers[cgoreceiver.Cgo]
-	cgoReceiver := cgoReceiverFactory.NewFunc(cgoReceiverFactory.Config, a.telemetry.Telemetry, analyzerManager)
+	cgoReceiver := cgoReceiverFactory.NewFunc(cgoReceiverFactory.Config, a.telemetry.GetTelemetryTools(cgoreceiver.Cgo), analyzerManager)
 	a.receiver = cgoReceiver
 	return nil
 }

--- a/collector/internal/application/application.go
+++ b/collector/internal/application/application.go
@@ -52,7 +52,7 @@ func New() (*Application, error) {
 }
 
 func (a *Application) Run() error {
-	err := a.analyzerManager.StartAll(a.telemetry.Logger)
+	err := a.analyzerManager.StartAll(a.telemetry.GetGlobalTelemetryTools().Logger)
 	if err != nil {
 		return fmt.Errorf("failed to start application: %v", err)
 	}
@@ -65,7 +65,7 @@ func (a *Application) Run() error {
 }
 
 func (a *Application) Shutdown() error {
-	return multierr.Combine(a.receiver.Shutdown(), a.analyzerManager.ShutdownAll(a.telemetry.Logger))
+	return multierr.Combine(a.receiver.Shutdown(), a.analyzerManager.ShutdownAll(a.telemetry.GetGlobalTelemetryTools().Logger))
 }
 
 func initFlags() error {

--- a/collector/pkg/component/analyzer/manager.go
+++ b/collector/pkg/component/analyzer/manager.go
@@ -3,8 +3,8 @@ package analyzer
 import (
 	"errors"
 
+	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"github.com/hashicorp/go-multierror"
-	"go.uber.org/zap"
 )
 
 const ConsumeAllEvents = "consumeAllEvents"
@@ -54,9 +54,9 @@ func NewManager(analyzers ...Analyzer) (*Manager, error) {
 	}, nil
 }
 
-func (m *Manager) StartAll(logger *zap.Logger) error {
+func (m *Manager) StartAll(logger *component.TelemetryLogger) error {
 	for _, analyzer := range m.allAnalyzers {
-		logger.Sugar().Infof("Starting analyzer [%s]", analyzer.Type())
+		logger.Infof("Starting analyzer [%s]", analyzer.Type())
 		err := analyzer.Start()
 		if err != nil {
 			return err
@@ -65,10 +65,10 @@ func (m *Manager) StartAll(logger *zap.Logger) error {
 	return nil
 }
 
-func (m *Manager) ShutdownAll(logger *zap.Logger) error {
+func (m *Manager) ShutdownAll(logger *component.TelemetryLogger) error {
 	var retErr error = nil
 	for _, analyzer := range m.allAnalyzers {
-		logger.Sugar().Infof("Shutdown analyzer [%s]", analyzer.Type())
+		logger.Infof("Shutdown analyzer [%s]", analyzer.Type())
 		err := analyzer.Shutdown()
 		if err != nil {
 			retErr = multierror.Append(retErr, err)

--- a/collector/pkg/component/analyzer/tcpconnectanalyzer/internal/connect_monitor.go
+++ b/collector/pkg/component/analyzer/tcpconnectanalyzer/internal/connect_monitor.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"github.com/Kindling-project/kindling/collector/pkg/model"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -17,12 +18,12 @@ type ConnectMonitor struct {
 	connMap        map[ConnKey]*ConnectionStats
 	statesResource StatesResource
 	hostProcPath   string
-	logger         *zap.Logger
+	logger         *component.TelemetryLogger
 }
 
 const HostProc = "HOST_PROC_PATH"
 
-func NewConnectMonitor(logger *zap.Logger) *ConnectMonitor {
+func NewConnectMonitor(logger *component.TelemetryLogger) *ConnectMonitor {
 	path, ok := os.LookupEnv(HostProc)
 	if !ok {
 		path = "/proc"

--- a/collector/pkg/component/consumer/exporter/otelexporter/consume.go
+++ b/collector/pkg/component/consumer/exporter/otelexporter/consume.go
@@ -2,7 +2,6 @@ package otelexporter
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/Kindling-project/kindling/collector/pkg/component/consumer/exporter/tools/adapter"
 	"github.com/Kindling-project/kindling/collector/pkg/model"
@@ -91,8 +90,8 @@ func (e *OtelExporter) exportMetric(result *adapter.AdaptedResult) {
 		} else if metric.DataType() == model.HistogramMetricType {
 			e.telemetry.Logger.Warn("Failed to exporter Metric: can not use otlp-exporter to export histogram Data", zap.String("MetricName", metric.Name))
 		} else {
-			if ce := e.telemetry.Logger.Check(zapcore.DebugLevel, "Undefined metricKind for this Metric"); ce != nil {
-				ce.Write(zap.String("MetricName", metric.Name), zap.String("MetricType", reflect.TypeOf(metric).String()))
+			if ce := e.telemetry.Logger.Check(zapcore.DebugLevel, "Undefined metricKind for this Metric in metric_aggregation_map"); ce != nil {
+				ce.Write(zap.String("MetricName", metric.Name))
 			}
 		}
 	}

--- a/collector/pkg/component/consumer/exporter/otelexporter/helper.go
+++ b/collector/pkg/component/consumer/exporter/otelexporter/helper.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -46,7 +47,7 @@ var commonLabels = []attribute.KeyValue{
 	attribute.String("instance", GetHostname()),
 }
 
-func GetCommonLabels(withUserInfo bool, logger *zap.Logger) []attribute.KeyValue {
+func GetCommonLabels(withUserInfo bool, logger *component.TelemetryLogger) []attribute.KeyValue {
 	var clusterId, userId string
 	var err error
 

--- a/collector/pkg/component/consumer/exporter/otelexporter/instrument.go
+++ b/collector/pkg/component/consumer/exporter/otelexporter/instrument.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/Kindling-project/kindling/collector/pkg/aggregator"
 	"github.com/Kindling-project/kindling/collector/pkg/aggregator/defaultaggregator"
+	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"github.com/Kindling-project/kindling/collector/pkg/component/consumer/exporter/tools/adapter"
 	"github.com/Kindling-project/kindling/collector/pkg/model"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constnames"
 	"go.opentelemetry.io/otel/attribute"
-	"go.uber.org/zap"
 
 	"go.opentelemetry.io/otel/metric"
 )
@@ -25,7 +25,7 @@ type instrumentFactory struct {
 	instruments  sync.Map
 	meter        metric.Meter
 	customLabels []attribute.KeyValue
-	logger       *zap.Logger
+	telemetry    *component.TelemetryTools
 
 	aggregator *defaultaggregator.DefaultAggregator
 
@@ -33,12 +33,12 @@ type instrumentFactory struct {
 	TcpRttMillsSelector   *aggregator.LabelSelectors
 }
 
-func newInstrumentFactory(meter metric.Meter, logger *zap.Logger, customLabels []attribute.KeyValue) *instrumentFactory {
+func newInstrumentFactory(meter metric.Meter, telemetry *component.TelemetryTools, customLabels []attribute.KeyValue) *instrumentFactory {
 	return &instrumentFactory{
 		instruments:  sync.Map{},
 		meter:        meter,
 		customLabels: customLabels,
-		logger:       logger,
+		telemetry:    telemetry,
 		aggregator: defaultaggregator.NewDefaultAggregator(&defaultaggregator.AggregatedConfig{
 			KindMap: map[string][]defaultaggregator.KindConfig{
 				constnames.TcpRttMetricName: {

--- a/collector/pkg/component/consumer/exporter/otelexporter/instrument_test.go
+++ b/collector/pkg/component/consumer/exporter/otelexporter/instrument_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Kindling-project/kindling/collector/pkg/model"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constnames"
-	"github.com/Kindling-project/kindling/collector/pkg/observability/logger"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/histogram"
 	controller "go.opentelemetry.io/otel/sdk/metric/controller/basic"
@@ -50,7 +49,7 @@ func Test_instrumentFactory_recordLastValue(t *testing.T) {
 		},
 	}
 
-	loggerInstance := logger.CreateConsoleLogger()
+	loggerInstance := component.NewDefaultTelemetryTools()
 	exporter, _ := newExporters(context.Background(), cfg, loggerInstance)
 
 	cont := controller.New(
@@ -64,7 +63,7 @@ func Test_instrumentFactory_recordLastValue(t *testing.T) {
 
 	cont.Start(context.Background())
 
-	ins := newInstrumentFactory(cont.Meter("test"), component.NewDefaultTelemetryTools().Logger, nil)
+	ins := newInstrumentFactory(cont.Meter("test"), component.NewDefaultTelemetryTools(), nil)
 
 	for i := 0; i < 10000; i++ {
 		time.Sleep(1 * time.Second)
@@ -150,7 +149,7 @@ func makeTraceAsMetricGroup(requestLatency int64, timestamp uint64, dstIp string
 }
 
 func Test_instrumentFactory_recordTraceAsMetric(t *testing.T) {
-	ins := newInstrumentFactory(metric.Meter{}, component.NewDefaultTelemetryTools().Logger, nil)
+	ins := newInstrumentFactory(metric.Meter{}, component.NewDefaultTelemetryTools(), nil)
 	metricName := constnames.TraceAsMetric
 	var randTime int64
 	var timestamp uint64

--- a/collector/pkg/component/consumer/exporter/otelexporter/otelexporter.go
+++ b/collector/pkg/component/consumer/exporter/otelexporter/otelexporter.go
@@ -239,7 +239,7 @@ func (e *OtelExporter) findInstrumentKind(metricName string) (MetricAggregationK
 // Crete new opentelemetry-go exporter.
 func newExporters(context context.Context, cfg *Config, telemetry *component.TelemetryTools) (*OtelOutputExporters, error) {
 	var retExporters *OtelOutputExporters
-	telemetry.Logger.Sugar().Infof("Initializing OpenTelemetry exporter whose type is %s", cfg.ExportKind)
+	telemetry.Logger.Infof("Initializing OpenTelemetry exporter whose type is %s", cfg.ExportKind)
 	switch cfg.ExportKind {
 	case StdoutKindExporter:
 		metricExp, err := stdoutmetric.New(

--- a/collector/pkg/component/consumer/exporter/otelexporter/prometheus.go
+++ b/collector/pkg/component/consumer/exporter/otelexporter/prometheus.go
@@ -15,14 +15,14 @@ func StartServer(exporter *prometheus.Exporter, telemetry *component.TelemetryTo
 		Handler: http.DefaultServeMux,
 	}
 
-	telemetry.Logger.Sugar().Infof("Prometheus Server listening at port: [%s]", port)
+	telemetry.Logger.Infof("Prometheus Server listening at port: [%s]", port)
 	err := srv.ListenAndServe()
 
 	if err != nil && err != http.ErrServerClosed {
 		return err
 	}
 
-	telemetry.Logger.Sugar().Infof("Prometheus gracefully shutdown the http server...\n")
+	telemetry.Logger.Infof("Prometheus gracefully shutdown the http server...\n")
 
 	return nil
 }

--- a/collector/pkg/component/consumer/exporter/otelexporter/prometheus.go
+++ b/collector/pkg/component/consumer/exporter/otelexporter/prometheus.go
@@ -3,11 +3,11 @@ package otelexporter
 import (
 	"net/http"
 
+	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"go.opentelemetry.io/otel/exporters/prometheus"
-	"go.uber.org/zap"
 )
 
-func StartServer(exporter *prometheus.Exporter, logger *zap.Logger, port string) error {
+func StartServer(exporter *prometheus.Exporter, telemetry *component.TelemetryTools, port string) error {
 	http.HandleFunc("/metrics", exporter.ServeHTTP)
 
 	srv := http.Server{
@@ -15,14 +15,14 @@ func StartServer(exporter *prometheus.Exporter, logger *zap.Logger, port string)
 		Handler: http.DefaultServeMux,
 	}
 
-	logger.Sugar().Infof("Prometheus Server listening at port: [%s]", port)
+	telemetry.Logger.Sugar().Infof("Prometheus Server listening at port: [%s]", port)
 	err := srv.ListenAndServe()
 
 	if err != nil && err != http.ErrServerClosed {
 		return err
 	}
 
-	logger.Sugar().Infof("Prometheus gracefully shutdown the http server...\n")
+	telemetry.Logger.Sugar().Infof("Prometheus gracefully shutdown the http server...\n")
 
 	return nil
 }

--- a/collector/pkg/component/consumer/exporter/prometheusexporter/collector.go
+++ b/collector/pkg/component/consumer/exporter/prometheusexporter/collector.go
@@ -4,11 +4,11 @@ import (
 	"time"
 
 	"github.com/Kindling-project/kindling/collector/pkg/aggregator/defaultaggregator"
+	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"github.com/Kindling-project/kindling/collector/pkg/model"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constnames"
 	"github.com/Kindling-project/kindling/collector/pkg/model/constvalues"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap"
 )
 
 type collector struct {
@@ -69,7 +69,7 @@ func (c *collector) recordMetricGroups(group *model.DataGroup) {
 	c.aggregator.AggregatorWithAllLabelsAndMetric(group, time.Now())
 }
 
-func newCollector(config *Config, logger *zap.Logger) *collector {
+func newCollector(config *Config, _ *component.TelemetryLogger) *collector {
 	// TODO Do this in config later !!!!
 	requestTimeHistogramTopologyMetric := constnames.ToKindlingNetMetricName(constvalues.RequestTimeHistogram, false)
 	requestTimeHistogramEntityMetric := constnames.ToKindlingNetMetricName(constvalues.RequestTimeHistogram, true)

--- a/collector/pkg/component/consumer/exporter/prometheusexporter/helper.go
+++ b/collector/pkg/component/consumer/exporter/prometheusexporter/helper.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Kindling-project/kindling/collector/pkg/component"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -46,7 +47,7 @@ var commonLabels = []attribute.KeyValue{
 	attribute.String("instance", GetHostname()),
 }
 
-func GetCommonLabels(withUserInfo bool, logger *zap.Logger) []attribute.KeyValue {
+func GetCommonLabels(withUserInfo bool, logger *component.TelemetryLogger) []attribute.KeyValue {
 	var clusterId, userId string
 	var err error
 

--- a/collector/pkg/component/consumer/exporter/prometheusexporter/prometheus.go
+++ b/collector/pkg/component/consumer/exporter/prometheusexporter/prometheus.go
@@ -62,7 +62,7 @@ func NewExporter(config interface{}, telemetry *component.TelemetryTools) export
 			registry,
 			promhttp.HandlerOpts{
 				ErrorHandling: promhttp.ContinueOnError,
-				ErrorLog:      &promLogger{realLog: telemetry.GetZapLogger()},
+				ErrorLog:      &promLogger{realLog: telemetry.Logger},
 			},
 		),
 		// metricAggregationMap: cfg.MetricAggregationMap,
@@ -118,10 +118,10 @@ func (p *prometheusExporter) Start(_ context.Context) error {
 }
 
 type promLogger struct {
-	realLog *zap.Logger
+	realLog *component.TelemetryLogger
 }
 
-func newPromLogger(zapLog *zap.Logger) *promLogger {
+func newPromLogger(zapLog *component.TelemetryLogger) *promLogger {
 	return &promLogger{
 		realLog: zapLog,
 	}

--- a/collector/pkg/component/consumer/exporter/prometheusexporter/prometheus.go
+++ b/collector/pkg/component/consumer/exporter/prometheusexporter/prometheus.go
@@ -62,7 +62,7 @@ func NewExporter(config interface{}, telemetry *component.TelemetryTools) export
 			registry,
 			promhttp.HandlerOpts{
 				ErrorHandling: promhttp.ContinueOnError,
-				ErrorLog:      &promLogger{realLog: telemetry.Logger},
+				ErrorLog:      &promLogger{realLog: telemetry.GetZapLogger()},
 			},
 		),
 		// metricAggregationMap: cfg.MetricAggregationMap,

--- a/collector/pkg/component/consumer/processor/k8sprocessor/kubernetes_processor.go
+++ b/collector/pkg/component/consumer/processor/k8sprocessor/kubernetes_processor.go
@@ -47,7 +47,7 @@ func NewKubernetesProcessor(cfg interface{}, telemetry *component.TelemetryTools
 	options = append(options, kubernetes.WithGraceDeletePeriod(config.GraceDeletePeriod))
 	err := kubernetes.InitK8sHandler(options...)
 	if err != nil {
-		telemetry.Logger.Sugar().Panicf("Failed to initialize [%s]: %v. Set the option 'enable' false if you want to run the agent in the non-Kubernetes environment.", K8sMetadata, err)
+		telemetry.Logger.Panicf("Failed to initialize [%s]: %v. Set the option 'enable' false if you want to run the agent in the non-Kubernetes environment.", K8sMetadata, err)
 		return nil
 	}
 

--- a/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
+++ b/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
@@ -41,7 +41,7 @@ type CgoReceiver struct {
 func NewCgoReceiver(config interface{}, telemetry *component.TelemetryTools, analyzerManager *analyzerpackage.Manager) receiver.Receiver {
 	cfg, ok := config.(*Config)
 	if !ok {
-		telemetry.Logger.Sugar().Panicf("Cannot convert [%s] config", Cgo)
+		telemetry.Logger.Panicf("Cannot convert [%s] config", Cgo)
 	}
 	cgoReceiver := &CgoReceiver{
 		cfg:             cfg,
@@ -174,7 +174,7 @@ func (r *CgoReceiver) subEvent() {
 	if len(r.cfg.SubscribeInfo) == 0 {
 		r.telemetry.Logger.Warn("No events are subscribed by cgoreceiver. Please check your configuration.")
 	} else {
-		r.telemetry.Logger.Sugar().Infof("The subscribed events are: %v", r.cfg.SubscribeInfo)
+		r.telemetry.Logger.Infof("The subscribed events are: %v", r.cfg.SubscribeInfo)
 	}
 	for _, value := range r.cfg.SubscribeInfo {
 		C.subEventForGo(C.CString(value.Name), C.CString(value.Category))

--- a/collector/pkg/component/telemetry.go
+++ b/collector/pkg/component/telemetry.go
@@ -83,8 +83,8 @@ func (t *TelemetryManager) SelectorOption(component string) TelemetryOption {
 	if len(t.Selector) == 0 {
 		return WithDebug(true)
 	}
-	for _, slectedComponent := range t.Selector {
-		if slectedComponent == component {
+	for _, selectedComponent := range t.Selector {
+		if selectedComponent == component {
 			return WithDebug(true)
 		}
 	}

--- a/collector/pkg/component/telemetry.go
+++ b/collector/pkg/component/telemetry.go
@@ -3,12 +3,13 @@ package component
 import (
 	"log"
 
-	observability2 "github.com/Kindling-project/kindling/collector/pkg/observability"
+	"github.com/Kindling-project/kindling/collector/pkg/observability"
 	"github.com/Kindling-project/kindling/collector/pkg/observability/logger"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/global"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -18,12 +19,16 @@ const (
 )
 
 type TelemetryManager struct {
-	Telemetry *TelemetryTools
+	MeterProvider metric.MeterProvider
+	Logger        *zap.Logger
+	Selector      []string
 }
 
 func NewTelemetryManager() *TelemetryManager {
 	return &TelemetryManager{
-		Telemetry: NewDefaultTelemetryTools(),
+		MeterProvider: metric.NewNoopMeterProvider(),
+		Logger:        logger.CreateDefaultLogger(),
+		Selector:      make([]string, 0),
 	}
 }
 
@@ -39,34 +44,110 @@ func (t *TelemetryManager) initLogger(viper *viper.Viper) {
 	if err != nil {
 		log.Printf("Error happened when reading logger config, and default config will be used: %v", err)
 	}
-	t.Telemetry.Logger = logger.InitLogger(loggerConfig)
+	t.Selector = loggerConfig.Selector
+	t.Logger = logger.InitLogger(loggerConfig)
 }
 
 func (t *TelemetryManager) initProvider(viper *viper.Viper) {
-	var config = &observability2.DefaultConfig
+	var config = &observability.DefaultConfig
 	key := ObservabilityConfig + "." + MetricKey
 	err := viper.UnmarshalKey(key, config)
 	if err != nil {
 		log.Printf("Error happened when reading observability config, and default config will be used: %v", err)
 	}
-	meterProvider, err := observability2.InitTelemetry(t.Telemetry.Logger, config)
+	meterProvider, err := observability.InitTelemetry(t.Logger, config)
 	if err != nil {
 		log.Printf("Error happened when initializing meter provider: %v", err)
 		return
 	}
-	t.Telemetry.MeterProvider = meterProvider
+	t.MeterProvider = meterProvider
 	// Here we set a global meter provider to make it accessible to all components
 	global.SetMeterProvider(meterProvider)
 }
 
+func (t *TelemetryManager) GetGlobalTelemetryTools() *TelemetryTools {
+	return t.getToolsWithOption(
+		WithDebug(true),
+	)
+}
+
+func (t *TelemetryManager) GetTelemetryTools(component string) *TelemetryTools {
+	options := make([]TelemetryOption, 0)
+	// DebugSelector
+	options = append(options, t.SelectorOption(component))
+
+	return t.getToolsWithOption(options...)
+}
+
+func (t *TelemetryManager) SelectorOption(component string) TelemetryOption {
+	if len(t.Selector) == 0 {
+		return WithDebug(true)
+	}
+	for _, slectedComponent := range t.Selector {
+		if slectedComponent == component {
+			return WithDebug(true)
+		}
+	}
+	return WithDebug(false)
+}
+
+func (t *TelemetryManager) getToolsWithOption(opts ...TelemetryOption) *TelemetryTools {
+	newSubTool := &TelemetryTools{
+		MeterProvider: t.MeterProvider,
+		Logger: &TelemetryLogger{
+			Logger: t.Logger,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(newSubTool)
+	}
+
+	return newSubTool
+}
+
+type TelemetryLogger struct {
+	*zap.Logger
+	EnableDebug bool
+}
+
 type TelemetryTools struct {
-	Logger        *zap.Logger
 	MeterProvider metric.MeterProvider
+	Logger        *TelemetryLogger
+}
+
+func (t *TelemetryTools) GetZapLogger() *zap.Logger {
+	return t.Logger.Logger
+}
+
+func (t *TelemetryLogger) Debug(msg string, fields ...zap.Field) {
+	if t.EnableDebug {
+		t.Logger.Debug(msg, fields...)
+	}
+}
+
+func (t *TelemetryLogger) Check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
+	if t.EnableDebug {
+		return t.Logger.Check(lvl, msg)
+	} else {
+		return nil
+	}
+}
+
+type TelemetryOption func(*TelemetryTools)
+
+func WithDebug(enableDebug bool) TelemetryOption {
+	return func(tt *TelemetryTools) {
+		tt.Logger.EnableDebug = enableDebug
+	}
 }
 
 func NewDefaultTelemetryTools() *TelemetryTools {
 	return &TelemetryTools{
-		Logger:        logger.CreateDefaultLogger(),
+		Logger: &TelemetryLogger{
+			Logger:      logger.CreateDefaultLogger(),
+			EnableDebug: true,
+		},
 		MeterProvider: metric.NewNoopMeterProvider(),
 	}
 }

--- a/collector/pkg/observability/logger/logger.go
+++ b/collector/pkg/observability/logger/logger.go
@@ -22,17 +22,17 @@ func CreateCombineLogger(config *lumberjack.Logger) *zap.Logger {
 		ConfigConsoleOutput(ConsoleEncodingConfig, consoleLogLevel),
 		ConfigFileRotationOutput(lumberJackEncodingConfig, config, lumberJackLogLevel),
 	)
-	return zap.New(core).WithOptions(zap.AddCaller())
+	return zap.New(core).WithOptions(zap.AddCaller(), zap.AddCallerSkip(1))
 }
 
 func CreateConsoleLogger() *zap.Logger {
 	core := ConfigConsoleOutput(ConsoleEncodingConfig, consoleLogLevel)
-	return zap.New(core).WithOptions(zap.AddCaller())
+	return zap.New(core).WithOptions(zap.AddCaller(), zap.AddCallerSkip(1))
 }
 
 func CreateFileRotationLogger(config *lumberjack.Logger) *zap.Logger {
 	core := ConfigFileRotationOutput(lumberJackEncodingConfig, config, lumberJackLogLevel)
-	return zap.New(core).WithOptions(zap.AddCaller())
+	return zap.New(core).WithOptions(zap.AddCaller(), zap.AddCallerSkip(1))
 }
 
 func InitLogger(config Config) *zap.Logger {

--- a/collector/pkg/observability/logger/logger.go
+++ b/collector/pkg/observability/logger/logger.go
@@ -12,6 +12,7 @@ var lumberJackLogLevel zapcore.Level
 type Config struct {
 	ConsoleLogLevel  string             `mapstructure:"console_level"`
 	FileLogLevel     string             `mapstructure:"file_level"`
+	Selector         []string           `mapstructure:"debug_selector"`
 	LumberJackConfig *lumberjack.Logger `mapstructure:"file_rotation"`
 }
 

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -159,10 +159,10 @@ observability:
   logger:
     console_level: info # debug,info,warn,error,none
     file_level: info
-    # debug_selector is used to filter debug_message from different components
-    # 1. This filter will not take effect when there is no element in debug_selector list
-    # 2. If list is not empty, only component contains in this list will print debug-message
-    # 3. The name of each component is defined above , such as `receiver.cgoreceiver`, `exporter.otelexporter`, only need the second part of config name
+    # debug_selector is used to filter debug message from different components
+    # 1. This filter will not take effect when there is no element in the debug_selector list
+    # 2. If the list is not empty, only the components contained in this list will print debug message
+    # 3. The name of each component is defined above, such as `receiver.cgoreceiver`, `exporter.otelexporter`, only the second part of the config name needed
     # e.g debug_selector: ["cgoreceiver","otelexporter"]
     debug_selector: []
     file_rotation:

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -160,9 +160,9 @@ observability:
     console_level: info # debug,info,warn,error,none
     file_level: info
     # debug_selector is used to filter debug_message from different components
-    # 1. this filter will not take effect when there is no element in debug_selector list
-    # 2. if list is not empty, only component contains in this list will print debug-message
-    # 3. the name of each component is defined above , such as `receiver.cgoreceiver`, `exporter.otelexporter`, only need the second part of config name
+    # 1. This filter will not take effect when there is no element in debug_selector list
+    # 2. If list is not empty, only component contains in this list will print debug-message
+    # 3. The name of each component is defined above , such as `receiver.cgoreceiver`, `exporter.otelexporter`, only need the second part of config name
     # e.g debug_selector: ["cgoreceiver","otelexporter"]
     debug_selector: []
     file_rotation:

--- a/deploy/agent/kindling-collector-config.yml
+++ b/deploy/agent/kindling-collector-config.yml
@@ -159,6 +159,12 @@ observability:
   logger:
     console_level: info # debug,info,warn,error,none
     file_level: info
+    # debug_selector is used to filter debug_message from different components
+    # 1. this filter will not take effect when there is no element in debug_selector list
+    # 2. if list is not empty, only component contains in this list will print debug-message
+    # 3. the name of each component is defined above , such as `receiver.cgoreceiver`, `exporter.otelexporter`, only need the second part of config name
+    # e.g debug_selector: ["cgoreceiver","otelexporter"]
+    debug_selector: []
     file_rotation:
       filename: agent.log
       maxsize: 512 #MB


### PR DESCRIPTION
## Description
add an option name debug_selector to filter debug_log from different components

## Related Issue
#298 

## NewOption named debug_selector
This option can be compatible with the previous version.
If this option is empty or not SETUP, all component will print their debug log normally.
``` yaml
observability:
  logger:
    console_level: info # debug,info,warn,error,none
    file_level: info
    # debug_selector is used to filter debug message from different components
    # 1. This filter will not take effect when there is no element in the debug_selector list
    # 2. If the list is not empty, only the components contained in this list will print debug message
    # 3. The name of each component is defined above, such as `receiver.cgoreceiver`, `exporter.otelexporter`, only the second part of the config name needed
    # e.g debug_selector: ["cgoreceiver","otelexporter"]
    debug_selector: []
```