### PR TITLE
Fix the userAttributes array out of range error caused by userAttNumber exceeding 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add a new environment variable: IS_PRINT_EVENT. When the value is true, sinsp events can be printed to the stdout. ([#283](https://github.com/CloudDectective-Harmonycloud/kindling/pull/283))
 - Declare the 9500 port in the agent's deployment file ([#282](https://github.com/CloudDectective-Harmonycloud/kindling/pull/282))
 ### Bug fixes 
+- Fix the userAttributes array out of range error caused by userAttNumber exceeding 8
 - Fix the bug where no HTTP headers were got. ([#301](https://github.com/CloudDectective-Harmonycloud/kindling/pull/301))
 - Fix the bug that need_trace_as_span options cannot take effect ([#292](https://github.com/CloudDectective-Harmonycloud/kindling/pull/292))
 - Fix connection failure rate data lost when change topology layout in the Grafana plugin. ([#289](https://github.com/CloudDectective-Harmonycloud/kindling/pull/289))

--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -266,8 +266,8 @@ int getEvent(void **pp_kindling_event)
 		memcpy(p_kindling_event->userAttributes[userAttNumber].value, &latency, 8);
 		p_kindling_event->userAttributes[userAttNumber].valueType = UINT64;
 		p_kindling_event->userAttributes[userAttNumber].len = 8;
+		userAttNumber++;
 	}
-	userAttNumber++;
 	switch(ev->get_type())
 	{
 	case PPME_TCP_RCV_ESTABLISHED_E:
@@ -342,6 +342,7 @@ int getEvent(void **pp_kindling_event)
 		{
 			paramsNumber = 8;
 		}
+		paramsNumber -= userAttNumber;
 		for(auto i = 0; i < paramsNumber; i++)
 		{
 

--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -270,90 +270,90 @@ int getEvent(void **pp_kindling_event)
 	}
 	switch(ev->get_type())
 	{
-	case PPME_TCP_RCV_ESTABLISHED_E:
-	case PPME_TCP_CLOSE_E:
-	{
-		auto pTuple = ev->get_param_value_raw("tuple");
-		userAttNumber = setTuple(p_kindling_event, pTuple, userAttNumber);
+		case PPME_TCP_RCV_ESTABLISHED_E:
+		case PPME_TCP_CLOSE_E:
+		{
+			auto pTuple = ev->get_param_value_raw("tuple");
+			userAttNumber = setTuple(p_kindling_event, pTuple, userAttNumber);
 
-		auto pRtt = ev->get_param_value_raw("srtt");
-		if(pRtt != NULL)
+			auto pRtt = ev->get_param_value_raw("srtt");
+			if(pRtt != NULL)
+			{
+				strcpy(p_kindling_event->userAttributes[userAttNumber].key, "rtt");
+				memcpy(p_kindling_event->userAttributes[userAttNumber].value, pRtt->m_val, pRtt->m_len);
+				p_kindling_event->userAttributes[userAttNumber].valueType = UINT32;
+				p_kindling_event->userAttributes[userAttNumber].len = pRtt->m_len;
+				userAttNumber++;
+			}
+			break;
+		}	
+		case PPME_TCP_CONNECT_X:
 		{
-			strcpy(p_kindling_event->userAttributes[userAttNumber].key, "rtt");
-			memcpy(p_kindling_event->userAttributes[userAttNumber].value, pRtt->m_val, pRtt->m_len);
-			p_kindling_event->userAttributes[userAttNumber].valueType = UINT32;
-			p_kindling_event->userAttributes[userAttNumber].len = pRtt->m_len;
-			userAttNumber++;
+			auto pTuple = ev->get_param_value_raw("tuple");
+			userAttNumber = setTuple(p_kindling_event, pTuple, userAttNumber);
+			auto pRetVal = ev->get_param_value_raw("retval");
+			if(pRetVal != NULL)
+			{
+				strcpy(p_kindling_event->userAttributes[userAttNumber].key, "retval");
+				memcpy(p_kindling_event->userAttributes[userAttNumber].value, pRetVal->m_val, pRetVal->m_len);
+				p_kindling_event->userAttributes[userAttNumber].valueType = UINT64;
+				p_kindling_event->userAttributes[userAttNumber].len = pRetVal->m_len;
+				userAttNumber++;
+			}
+			break;
 		}
-		break;
-	}
-	case PPME_TCP_CONNECT_X:
-	{
-		auto pTuple = ev->get_param_value_raw("tuple");
-		userAttNumber = setTuple(p_kindling_event, pTuple, userAttNumber);
-		auto pRetVal = ev->get_param_value_raw("retval");
-		if(pRetVal != NULL)
+		case PPME_TCP_DROP_E:
+		case PPME_TCP_RETRANCESMIT_SKB_E:
+		case PPME_TCP_SET_STATE_E:
 		{
-			strcpy(p_kindling_event->userAttributes[userAttNumber].key, "retval");
-			memcpy(p_kindling_event->userAttributes[userAttNumber].value, pRetVal->m_val, pRetVal->m_len);
-			p_kindling_event->userAttributes[userAttNumber].valueType = UINT64;
-			p_kindling_event->userAttributes[userAttNumber].len = pRetVal->m_len;
-			userAttNumber++;
+			auto pTuple = ev->get_param_value_raw("tuple");
+			userAttNumber = setTuple(p_kindling_event, pTuple, userAttNumber);
+			auto old_state = ev->get_param_value_raw("old_state");
+			if(old_state != NULL)
+			{
+				strcpy(p_kindling_event->userAttributes[userAttNumber].key, "old_state");
+				memcpy(p_kindling_event->userAttributes[userAttNumber].value, old_state->m_val, old_state->m_len);
+				p_kindling_event->userAttributes[userAttNumber].len = old_state->m_len;
+				p_kindling_event->userAttributes[userAttNumber].valueType = INT32;
+				userAttNumber++;
+			}
+			auto new_state = ev->get_param_value_raw("new_state");
+			if(new_state != NULL)
+			{
+				strcpy(p_kindling_event->userAttributes[userAttNumber].key, "new_state");
+				memcpy(p_kindling_event->userAttributes[userAttNumber].value, new_state->m_val, new_state->m_len);
+				p_kindling_event->userAttributes[userAttNumber].valueType = INT32;
+				p_kindling_event->userAttributes[userAttNumber].len = new_state->m_len;
+				userAttNumber++;
+			}
+			break;
 		}
-		break;
-	}
-	case PPME_TCP_DROP_E:
-	case PPME_TCP_RETRANCESMIT_SKB_E:
-	case PPME_TCP_SET_STATE_E:
-	{
-		auto pTuple = ev->get_param_value_raw("tuple");
-		userAttNumber = setTuple(p_kindling_event, pTuple, userAttNumber);
-		auto old_state = ev->get_param_value_raw("old_state");
-		if(old_state != NULL)
+		case PPME_TCP_SEND_RESET_E:
+		case PPME_TCP_RECEIVE_RESET_E:
 		{
-			strcpy(p_kindling_event->userAttributes[userAttNumber].key, "old_state");
-			memcpy(p_kindling_event->userAttributes[userAttNumber].value, old_state->m_val, old_state->m_len);
-			p_kindling_event->userAttributes[userAttNumber].len = old_state->m_len;
-			p_kindling_event->userAttributes[userAttNumber].valueType = INT32;
-			userAttNumber++;
+			auto pTuple = ev->get_param_value_raw("tuple");
+			userAttNumber = setTuple(p_kindling_event, pTuple, userAttNumber);
+			break;
 		}
-		auto new_state = ev->get_param_value_raw("new_state");
-		if(new_state != NULL)
+		default:
 		{
-			strcpy(p_kindling_event->userAttributes[userAttNumber].key, "new_state");
-			memcpy(p_kindling_event->userAttributes[userAttNumber].value, new_state->m_val, new_state->m_len);
-			p_kindling_event->userAttributes[userAttNumber].valueType = INT32;
-			p_kindling_event->userAttributes[userAttNumber].len = new_state->m_len;
-			userAttNumber++;
-		}
-		break;
-	}
-	case PPME_TCP_SEND_RESET_E:
-	case PPME_TCP_RECEIVE_RESET_E:
-	{
-		auto pTuple = ev->get_param_value_raw("tuple");
-		userAttNumber = setTuple(p_kindling_event, pTuple, userAttNumber);
-		break;
-	}
-	default:
-	{
-		uint16_t paramsNumber = ev->get_num_params();
-		if(paramsNumber > 8)
-		{
-			paramsNumber = 8;
-		}
-		paramsNumber -= userAttNumber;
-		for(auto i = 0; i < paramsNumber; i++)
-		{
+			uint16_t paramsNumber = ev->get_num_params();
+			if(paramsNumber > 8)
+			{
+				paramsNumber = 8;
+			}
+			paramsNumber -= userAttNumber;
+			for(auto i = 0; i < paramsNumber; i++)
+			{
 
-			strcpy(p_kindling_event->userAttributes[userAttNumber].key, (char *)ev->get_param_name(i));
-			memcpy(p_kindling_event->userAttributes[userAttNumber].value, ev->get_param(i)->m_val,
-			       ev->get_param(i)->m_len);
-			p_kindling_event->userAttributes[userAttNumber].len = ev->get_param(i)->m_len;
-			p_kindling_event->userAttributes[userAttNumber].valueType = get_type(ev->get_param_info(i)->type);
-			userAttNumber++;
+				strcpy(p_kindling_event->userAttributes[userAttNumber].key, (char *)ev->get_param_name(i));
+				memcpy(p_kindling_event->userAttributes[userAttNumber].value, ev->get_param(i)->m_val,
+			       	ev->get_param(i)->m_len);
+				p_kindling_event->userAttributes[userAttNumber].len = ev->get_param(i)->m_len;
+				p_kindling_event->userAttributes[userAttNumber].valueType = get_type(ev->get_param_info(i)->type);
+				userAttNumber++;
+			}
 		}
-	}
 	}
 	p_kindling_event->paramsNumber = userAttNumber;
 	strcpy(p_kindling_event->name, (char *)ev->get_name());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix the userAttributes array out of range error caused by userAttNumber exceeding 8. 

## Motivation and Context
When we capture the system call, we will take latency as the first value of the userattribute array(After, I may prefer not to use this method. For specific changes, please refer to the PR about slow system call implementation that I will submit later), and the userattnumber + + statement is not associated with it (even if we do not capture the system call, the userattnumber will be increased by 1), and for the subsequent code, we do not limit the userattnumber to 8, which means that if an event with more than 7 parameters is captured, the array will be out of bounds. 
