### PR TITLE
fix: make TelemetryLogger print log correctly

### DIFF
--- a/collector/pkg/component/telemetry.go
+++ b/collector/pkg/component/telemetry.go
@@ -145,15 +145,15 @@ func (t *TelemetryLogger) Panic(msg string, fields ...zap.Field) {
 }
 
 func (t *TelemetryLogger) Infof(template string, args ...interface{}) {
-	t.sugar.Infof(template, args)
+	t.sugar.Infof(template, args...)
 }
 
 func (t *TelemetryLogger) Errorf(template string, args ...interface{}) {
-	t.sugar.Errorf(template, args)
+	t.sugar.Errorf(template, args...)
 }
 
 func (t *TelemetryLogger) Panicf(template string, args ...interface{}) {
-	t.sugar.Panicf(template, args)
+	t.sugar.Panicf(template, args...)
 }
 
 func (t *TelemetryLogger) Check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {

--- a/collector/pkg/component/telemetry_test.go
+++ b/collector/pkg/component/telemetry_test.go
@@ -1,0 +1,105 @@
+package component
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestTelemetryManager_DebugSelector(t *testing.T) {
+	tm := NewTelemetryManager()
+	type args struct {
+		options []TelemetryOption
+	}
+	type want struct {
+		entry []observer.LoggedEntry
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "EnableDebug",
+			args: args{
+				options: []TelemetryOption{WithDebug(true)},
+			},
+			want: want{
+				entry: []observer.LoggedEntry{
+					{
+						Entry:   zapcore.Entry{Level: zap.DebugLevel, Message: "Debug Test"},
+						Context: []zap.Field{zap.Int("int", 1)},
+					},
+				},
+			},
+		},
+		{
+			name: "DisableDebug",
+			args: args{
+				options: []TelemetryOption{WithDebug(false)},
+			},
+			want: want{
+				entry: []observer.LoggedEntry{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withLogger(t, zap.DebugLevel, nil, tt.args.options, tm, func(logger *TelemetryLogger, obs *observer.ObservedLogs) {
+				logger.Debug("Debug Test", zap.Int("int", 1))
+				assert.Equal(
+					t,
+					tt.want.entry,
+					obs.AllUntimed(),
+					"Unexpected log output from Debug log",
+				)
+			})
+		})
+	}
+}
+
+func TestTelemetryLogger_TestInfo(t *testing.T) {
+	tm := NewTelemetryManager()
+	withLogger(t, zap.InfoLevel, nil, nil, tm, func(logger *TelemetryLogger, obs *observer.ObservedLogs) {
+		logger.Info("Info Test", zap.Int("field", 1))
+		assert.Equal(
+			t,
+			[]observer.LoggedEntry{
+				{
+					Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "Info Test"},
+					Context: []zap.Field{zap.Int("field", 1)},
+				},
+			},
+			obs.AllUntimed(),
+			"Unexpected log output from Info log",
+		)
+	})
+}
+
+func TestTelemetryLogger_TestInfof(t *testing.T) {
+	tm := NewTelemetryManager()
+	withLogger(t, zap.InfoLevel, nil, nil, tm, func(logger *TelemetryLogger, obs *observer.ObservedLogs) {
+		logger.Infof("Info format Test: int field \"%d\" , string field \"%s\"", 1, "testStr")
+		assert.Equal(
+			t,
+			[]observer.LoggedEntry{
+				{
+					Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "Info format Test: int field \"1\" , string field \"testStr\""},
+					Context: []zap.Field{},
+				},
+			},
+			obs.AllUntimed(),
+			"Unexpected log output from Infof log",
+		)
+	})
+}
+
+func withLogger(t testing.TB, e zapcore.LevelEnabler, zapOpt []zap.Option, opts []TelemetryOption, tm *TelemetryManager, f func(*TelemetryLogger, *observer.ObservedLogs)) {
+	fac, logs := observer.New(e)
+	tm.Logger = zap.New(fac, zapOpt...)
+	tools := tm.getToolsWithOption(opts...)
+	f(tools.Logger, logs)
+}


### PR DESCRIPTION
TelemetryLogger calling the `zap.Sugar.Infof()`  in the wrong way

## Description
When calling `telemetry.Logger.Infof("xxx %d and xxx %s", 1 , "string")`

What we expected: `xxx 1 and xxx string`

Actual output: `xxx [200 %!d(string=string)] and xxx %!s(MISSING)`

## How Has This Been Tested?
```
go test -timeout 60m -run ^(TestTelemetryManager_DebugSelector|TestTelemetryLogger_TestInfo|TestTelemetryLogger_TestInfof)$ github.com/Kindling-project/kindling/collector/pkg/component

=== RUN   TestTelemetryManager_DebugSelector
=== RUN   TestTelemetryManager_DebugSelector/EnableDebug
=== RUN   TestTelemetryManager_DebugSelector/DisableDebug
--- PASS: TestTelemetryManager_DebugSelector (0.00s)
    --- PASS: TestTelemetryManager_DebugSelector/EnableDebug (0.00s)
    --- PASS: TestTelemetryManager_DebugSelector/DisableDebug (0.00s)
=== RUN   TestTelemetryLogger_TestInfo
--- PASS: TestTelemetryLogger_TestInfo (0.00s)
=== RUN   TestTelemetryLogger_TestInfof
--- PASS: TestTelemetryLogger_TestInfof (0.00s)
PASS
ok      github.com/Kindling-project/kindling/collector/pkg/component    0.014s
```