### PR TITLE
fix issue306 (runtime error when run TestHttpProtocol)

### DIFF
--- a/collector/pkg/component/analyzer/network/network_analyzer_test.go
+++ b/collector/pkg/component/analyzer/network/network_analyzer_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network/protocol/factory"
 	"reflect"
 	"sync"
 	"testing"
@@ -82,6 +83,7 @@ func prepareNetworkAnalyzer() *NetworkAnalyzer {
 			nextConsumers: []consumer.Consumer{&NopProcessor{}},
 			telemetry:     component.NewDefaultTelemetryTools(),
 		}
+		na.parserFactory = factory.NewParserFactory(factory.WithUrlClusteringMethod(na.cfg.UrlClusteringMethod))
 		na.Start()
 	}
 	return na


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
the map protocolParsers is nil, so f.protocolParsers[key] is error.
to fix it, na.parserFactory must have value.
let:
na.parserFactory = factory.NewParserFactory(factory.WithUrlClusteringMethod(na.cfg.UrlClusteringMethod))
can fix easily this bug.

## Related Issue
closes #306 

