### PR TITLE
fix: All NetRequestData is missing due to missing key attributes named `data`

### DIFF
--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -13,6 +13,7 @@ static sinsp *inspector = nullptr;
 sinsp_evt_formatter *formatter = nullptr;
 bool printEvent = false;
 int cnt = 0;
+int MAX_USERATTR_NUM = 8;
 map<string, ppm_event_type> m_events;
 map<string, Category> m_categories;
 int16_t event_filters[1024][16];
@@ -338,11 +339,12 @@ int getEvent(void **pp_kindling_event)
 		default:
 		{
 			uint16_t paramsNumber = ev->get_num_params();
-			if(paramsNumber > 8)
+			// Since current data structure specifies the maximum count of `user_attributes` 
+			if ((paramsNumber + userAttNumber) > MAX_USERATTR_NUM )
 			{
-				paramsNumber = 8;
+				paramsNumber =  MAX_USERATTR_NUM - userAttNumber;
 			}
-			paramsNumber -= userAttNumber;
+			// TODO Add another branch to verify the number of userAttNumber is less than MAX_USERATTR_NUM after the program becomes more complexd
 			for(auto i = 0; i < paramsNumber; i++)
 			{
 


### PR DESCRIPTION
After PR #302, the Kindling agent would miss all NetRequestData processed by the network analyzer.

https://github.com/CloudDectective-Harmonycloud/kindling/blob/bbd63ce0754a1bec85b7401694cce7652c8845c3/probe/src/cgo/kindling.cpp#L340-L355

The above statement was used to limit the maximum number of `userAttr` but discarded attributes mistakenly most of the time. When `data` is involved, the network analyzer will behave incorrectly.


