### PR TITLE
exit when failed to start probe

### DIFF
--- a/collector/pkg/component/receiver/cgoreceiver/cgo_func.h
+++ b/collector/pkg/component/receiver/cgoreceiver/cgo_func.h
@@ -8,7 +8,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-void runForGo();
+int runForGo();
 int getKindlingEvent(void **kindlingEvent);
 int subEventForGo(char* eventName, char* category);
 #ifdef __cplusplus

--- a/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
+++ b/collector/pkg/component/receiver/cgoreceiver/cgoreceiver.go
@@ -58,7 +58,10 @@ func NewCgoReceiver(config interface{}, telemetry *component.TelemetryTools, ana
 
 func (r *CgoReceiver) Start() error {
 	r.telemetry.Logger.Info("Start CgoReceiver")
-	C.runForGo()
+	res := int(C.runForGo())
+	if res == 1 {
+	    return fmt.Errorf("fail to init probe")
+	}
 	time.Sleep(2 * time.Second)
 	r.subEvent()
 	// Wait for the C routine running

--- a/probe/src/cgo/cgo_func.cpp
+++ b/probe/src/cgo/cgo_func.cpp
@@ -6,8 +6,8 @@
 #include "kindling.h"
 
 
-void runForGo(){
-	init_probe();
+int runForGo(){
+	return init_probe();
 }
 
 int getKindlingEvent(void **kindlingEvent){

--- a/probe/src/cgo/cgo_func.h
+++ b/probe/src/cgo/cgo_func.h
@@ -8,7 +8,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-void runForGo();
+int runForGo();
 int getKindlingEvent(void **kindlingEvent);
 void subEventForGo(char* eventName, char* category);
 #ifdef __cplusplus

--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -61,7 +61,7 @@ void sub_event(char *eventName, char *category)
 	}
 }
 
-void init_probe()
+int init_probe()
 {
 	bool bpf = false;
 	char* isPrintEvent = getenv("IS_PRINT_EVENT");
@@ -131,8 +131,9 @@ void init_probe()
 	catch(const exception &e)
 	{
 		fprintf(stderr, "kindling probe init err: %s", e.what());
-		exit(1);
+		return 1;
 	}
+    return 0;
 }
 
 int getEvent(void **pp_kindling_event)

--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -131,6 +131,7 @@ void init_probe()
 	catch(const exception &e)
 	{
 		fprintf(stderr, "kindling probe init err: %s", e.what());
+		exit(1);
 	}
 }
 

--- a/probe/src/cgo/kindling.h
+++ b/probe/src/cgo/kindling.h
@@ -6,7 +6,7 @@
 #define SYSDIG_KINDLING_H
 #include "sinsp.h"
 
-void init_probe();
+int init_probe();
 int getEvent(void **kindlingEvent);
 uint16_t get_kindling_category(sinsp_evt *sEvt);
 void init_sub_label();


### PR DESCRIPTION
## Motivation
I notice that if probe fails to start, huge logs of program stacks will appear because of nil pointer, which makes no sense.
Just exit program when failed to start probe, make the error log obvious.

No image here.