### PR TITLE
Increase the payload size of events to 200

### DIFF
--- a/probe/src/cgo/kindling.cpp
+++ b/probe/src/cgo/kindling.cpp
@@ -77,7 +77,7 @@ int init_probe()
 	{
 		inspector = new sinsp();
 		inspector->set_hostname_and_port_resolution_mode(false);
-		inspector->set_snaplen(80);
+		inspector->set_snaplen(200);
 
 		inspector->suppress_events_comm("containerd");
 		inspector->suppress_events_comm("dockerd");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Increase the payload size of events to 200 in Probe. Note that Collector also controls the output payload size according to the configuration file.
``` yaml
    protocol_config:
      - key: "http"
        ports: [ 80 ]
        # payload_length indicates the maximum size that payload can be fetched for target protocol
        # The trace data sent may contain such payload, so the higher this value, the larger network traffic.
        payload_length: 200
        slow_threshold: 500
```

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
#314