### PR TITLE
Add extra labels for the Metrics of Redis' Requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## Unreleased 
 ### Enhancements
-- Add extra labels for the Metrics of Redis' Requests. ([#321](https://github.com/CloudDectective-Harmonycloud/kindling/pull/321))
+- When processing Redis' Request, add additional labels to describe the key information of the message. Check [Metrics Document](https://github.com/CloudDectective-Harmonycloud/kindling/blob/main/docs/prometheus_metrics.md) for more detail. ([#321](https://github.com/CloudDectective-Harmonycloud/kindling/pull/321))
 
 ## v0.4.0 - 2022-09-19
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## Unreleased 
 ### Enhancements
-- When processing Redis' Request, add additional labels to describe the key information of the message. Check [Metrics Document](https://github.com/CloudDectective-Harmonycloud/kindling/blob/main/docs/prometheus_metrics.md) for more detail. ([#321](https://github.com/CloudDectective-Harmonycloud/kindling/pull/321))
+- When processing Redis' Requests, add additional labels to describe the key information of the message. Check [Metrics Document](https://github.com/CloudDectective-Harmonycloud/kindling/blob/main/docs/prometheus_metrics.md) for more details. ([#321](https://github.com/CloudDectective-Harmonycloud/kindling/pull/321))
 
 ## v0.4.0 - 2022-09-19
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 2. Records in this file are not identical to the title of their Pull Requests. A detailed description is necessary for understanding what changes are and why they are made.
 
 ## Unreleased 
+### Enhancements
+- Add extra labels for the Metrics of Redis' Requests. ([#321](https://github.com/CloudDectective-Harmonycloud/kindling/pull/321))
 
 ## v0.4.0 - 2022-09-19
 ### Enhancements

--- a/collector/pkg/component/analyzer/network/protocol/redis/redis_bulk_string.go
+++ b/collector/pkg/component/analyzer/network/protocol/redis/redis_bulk_string.go
@@ -49,7 +49,8 @@ func parseRedisBulkString() protocol.ParsePkgFn {
 
 		command := string(data)
 		if !message.HasAttribute(command) && IsRedisCommand(data) {
-			message.AddUtf8StringAttribute(constlabels.Sql, command)
+			message.AddUtf8StringAttribute(constlabels.ContentKey, command)
+			message.AddUtf8StringAttribute(constlabels.RedisCommand, command)
 		}
 
 		message.Offset = offset

--- a/collector/pkg/component/analyzer/network/protocol/redis/redis_error.go
+++ b/collector/pkg/component/analyzer/network/protocol/redis/redis_error.go
@@ -24,6 +24,8 @@ func parseRedisError() protocol.ParsePkgFn {
 		message.Offset = offset
 		if len(data) > 0 && !message.HasAttribute(constlabels.RedisErrMsg) {
 			message.AddByteArrayUtf8Attribute(constlabels.RedisErrMsg, data)
+			message.AddBoolAttribute(constlabels.IsError, true)
+			message.AddIntAttribute(constlabels.ErrorType, int64(constlabels.ProtocolError))
 		}
 		return true, message.IsComplete()
 	}

--- a/collector/pkg/component/analyzer/network/protocol/testdata/redis/server-trace-get.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/redis/server-trace-get.yml
@@ -42,6 +42,7 @@ trace:
         is_slow: false
         is_server: true
         protocol: "redis"
-        sql: "get"
+        content_key: "get"
+        redis_command: "get"
         is_error: false
         error_type: 0

--- a/collector/pkg/component/consumer/exporter/tools/adapter/label_converter.go
+++ b/collector/pkg/component/consumer/exporter/tools/adapter/label_converter.go
@@ -81,6 +81,8 @@ func updateProtocolKey(key *extraLabelsKey, labels *model.AttributeMap) *extraLa
 		key.protocol = KAFKA
 	case constvalues.ProtocolDubbo:
 		key.protocol = DUBBO
+	case constvalues.ProtocolRedis:
+		key.protocol = REDIS
 	default:
 		key.protocol = UNSUPPORTED
 	}

--- a/collector/pkg/component/consumer/exporter/tools/adapter/label_converter.go
+++ b/collector/pkg/component/consumer/exporter/tools/adapter/label_converter.go
@@ -293,6 +293,18 @@ func (m *LabelConverter) transform(group *model.DataGroup) (*model.AttributeMap,
 			attrsMap.AddBoolValue(attrs.metricsDicList[i].newKey, labels.GetBoolValue(attrs.metricsDicList[i].originKey))
 		case FromInt64ToString:
 			attrsMap.AddStringValue(attrs.metricsDicList[i].newKey, strconv.FormatInt(labels.GetIntValue(attrs.metricsDicList[i].originKey), 10))
+		case FromProtoclErrorToString:
+			if labels.GetIntValue(constlabels.ErrorType) == constlabels.ProtocolError {
+				attrsMap.AddStringValue(attrs.metricsDicList[i].newKey, constvalues.ProtocolError)
+			} else {
+				attrsMap.AddStringValue(attrs.metricsDicList[i].newKey, constvalues.ProtocolNoError)
+			}
+		case FromProtocolErrorToStatus:
+			if labels.GetIntValue(constlabels.ErrorType) == constlabels.ProtocolError {
+				attrsMap.AddStringValue(attrs.metricsDicList[i].newKey, constvalues.ProtocolErrorStatus)
+			} else {
+				attrsMap.AddStringValue(attrs.metricsDicList[i].newKey, constvalues.ProtocolNoErrorStatus)
+			}
 		case StrEmpty:
 			attrsMap.AddStringValue(attrs.metricsDicList[i].newKey, constlabels.STR_EMPTY)
 		}
@@ -348,6 +360,18 @@ func (m *LabelConverter) convert(group *model.DataGroup) ([]attribute.KeyValue, 
 			attrsList[attrs.sortMap[i]].Value = attribute.BoolValue(labels.GetBoolValue(attrs.metricsDicList[i].originKey))
 		case FromInt64ToString:
 			attrsList[attrs.sortMap[i]].Value = attribute.StringValue(strconv.FormatInt(labels.GetIntValue(attrs.metricsDicList[i].originKey), 10))
+		case FromProtoclErrorToString:
+			if labels.GetIntValue(constlabels.ErrorType) == constlabels.ProtocolError {
+				attrsList[attrs.sortMap[i]].Value = attribute.StringValue(constvalues.ProtocolError)
+			} else {
+				attrsList[attrs.sortMap[i]].Value = attribute.StringValue(constvalues.ProtocolNoError)
+			}
+		case FromProtocolErrorToStatus:
+			if labels.GetIntValue(constlabels.ErrorType) == constlabels.ProtocolError {
+				attrsList[attrs.sortMap[i]].Value = attribute.StringValue(constvalues.ProtocolErrorStatus)
+			} else {
+				attrsList[attrs.sortMap[i]].Value = attribute.StringValue(constvalues.ProtocolNoErrorStatus)
+			}
 		case StrEmpty:
 			attrsList[attrs.sortMap[i]].Value = attribute.StringValue(constlabels.STR_EMPTY)
 		}

--- a/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
+++ b/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
@@ -17,6 +17,7 @@ const (
 	MYSQL
 	GRPC
 	DUBBO
+	REDIS
 	UNSUPPORTED
 )
 
@@ -204,6 +205,10 @@ var entityProtocol = []extraLabelsParam{
 		{constlabels.RequestContent, constlabels.ContentKey, String},
 		{constlabels.ResponseContent, constlabels.DubboErrorCode, FromInt64ToString},
 	}, extraLabelsKey{DUBBO}},
+	{[]dictionary{
+		{constlabels.RequestContent, constlabels.ContentKey, String},
+		{constlabels.ResponseContent, constlabels.RedisErrMsg, FromInt64ToString},
+	}, extraLabelsKey{REDIS}},
 	{[]dictionary{
 		{constlabels.RequestContent, constlabels.STR_EMPTY, StrEmpty},
 		{constlabels.ResponseContent, constlabels.STR_EMPTY, StrEmpty},

--- a/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
+++ b/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
@@ -29,6 +29,8 @@ const (
 	Bool
 	StrEmpty
 	FromInt64ToString
+	FromProtoclErrorToString
+	FromProtocolErrorToStatus
 )
 
 const (
@@ -207,7 +209,7 @@ var entityProtocol = []extraLabelsParam{
 	}, extraLabelsKey{DUBBO}},
 	{[]dictionary{
 		{constlabels.RequestContent, constlabels.ContentKey, String},
-		{constlabels.ResponseContent, constlabels.RedisErrMsg, FromInt64ToString},
+		{constlabels.ResponseContent, constlabels.STR_EMPTY, FromProtoclErrorToString},
 	}, extraLabelsKey{REDIS}},
 	{[]dictionary{
 		{constlabels.RequestContent, constlabels.STR_EMPTY, StrEmpty},
@@ -241,6 +243,10 @@ var spanProtocol = []extraLabelsParam{
 		{constlabels.SpanDubboResponseBody, constlabels.DubboResponsePayload, String},
 		{constlabels.SpanDubboErrorCode, constlabels.DubboErrorCode, Int64},
 	}, extraLabelsKey{DUBBO}},
+	{[]dictionary{
+		{constlabels.SpanRedisCommand, constlabels.RedisCommand, String},
+		{constlabels.SpanRedisErrorMsg, constlabels.RedisErrMsg, String},
+	}, extraLabelsKey{REDIS}},
 	{
 		[]dictionary{}, extraLabelsKey{UNSUPPORTED},
 	},
@@ -266,6 +272,9 @@ var topologyProtocol = []extraLabelsParam{
 	{[]dictionary{
 		{constlabels.StatusCode, constlabels.DubboErrorCode, FromInt64ToString},
 	}, extraLabelsKey{DUBBO}},
+	{[]dictionary{
+		{constlabels.StatusCode, constlabels.STR_EMPTY, FromProtocolErrorToStatus},
+	}, extraLabelsKey{REDIS}},
 	{[]dictionary{
 		{constlabels.StatusCode, constlabels.STR_EMPTY, StrEmpty},
 	}, extraLabelsKey{UNSUPPORTED}},

--- a/collector/pkg/model/constlabels/const.go
+++ b/collector/pkg/model/constlabels/const.go
@@ -103,6 +103,9 @@ const (
 	SpanDubboRequestBody  = "dubbo.request_body"
 	SpanDubboResponseBody = "dubbo.response_body"
 
+	SpanRedisCommand  = "redis.command"
+	SpanRedisErrorMsg = "redis.error_msg"
+
 	NetWorkAnalyzeMetricGroup = "netAnalyzeMetrics"
 )
 const (

--- a/collector/pkg/model/constlabels/protocols.go
+++ b/collector/pkg/model/constlabels/protocols.go
@@ -20,7 +20,8 @@ const (
 	SqlErrCode = "sql_error_code"
 	SqlErrMsg  = "sql_error_msg"
 
-	RedisErrMsg = "redis_error_msg"
+	RedisCommand = "redis_command"
+	RedisErrMsg  = "redis_error_msg"
 
 	KafkaApi           = "kafka_api"
 	KafkaVersion       = "kafka_version"

--- a/collector/pkg/model/constvalues/const.go
+++ b/collector/pkg/model/constvalues/const.go
@@ -13,6 +13,12 @@ const (
 	ResponseIo = "response_io"
 
 	SpanInfo = "KSpanInfo"
+
+	ProtocolError   = "error"
+	ProtocolNoError = "noerror"
+
+	ProtocolErrorStatus   = "1"
+	ProtocolNoErrorStatus = "0"
 )
 
 const (

--- a/collector/pkg/model/constvalues/const.go
+++ b/collector/pkg/model/constvalues/const.go
@@ -23,4 +23,5 @@ const (
 	ProtocolDns   = "dns"
 	ProtocolKafka = "kafka"
 	ProtocolMysql = "mysql"
+	ProtocolRedis = "redis"
 )

--- a/docs/prometheus_metrics.md
+++ b/docs/prometheus_metrics.md
@@ -68,6 +68,13 @@ Service metrics are generated from the server-side events, which are used to sho
 | `request_content` | io.kindling.dubbo.api.service.OrderService#order | Service Info. The format of service is `package.class#method`                                                                                            |
 | `response_content` | 20 | "error_code" of Dubbo. 20 means OK, more details at the [docs](https://dubbo.apache.org/en/blog/2018/10/05/introduction-to-the-dubbo-protocol/#dubbo-protocol-details). |
 
+- When protocol is `redis`:
+
+| **Label** | **Example**                   | **Notes**                           |
+| --- |-------------------------|--------------------------|
+| `request_content` | GET | The command of the Redis request. |
+| `response_content` | noerror | The value is either `error` or `noerror`. |
+
 - For other cases, the `request_content` and `response_content` are both empty.
 
 **Note 3**: The histogram metric `kindling_entity_request_average_duration_nanoseconds_*` is disabled by default as it could be high-cardinality. If this metric is needed, please add a new line to the `exporters.otelexporter.metric_aggregation_map` section of the configuration file.
@@ -128,11 +135,12 @@ These two terms are composed of two parts.
 
 **Note 2**: The field "status_code" holds different values when "protocol" is different.
 
-- **HTTP**: 'Status Code' of HTTP response. 
-- **DNS**: rcode of DNS response.
-- **MySQL**: Error code of the error response.
-- **DUBBO**: 'Error Code' of Dubbo request.
-- **others**: empty temporarily
+- **http**: `Status Code` of HTTP response.
+- **dns**: `rcode` of DNS response.
+- **mysql**: `Error Code` of the error response.
+- **dubbo**: `Error Code` of Dubbo request.
+- **redis**: `0` if there is no error; `1` otherwise.
+- **others**: empty temporarily.
 
 **Note 3**: The histogram metric `kindling_topology_request_average_duration_nanoseconds_*` is disabled by default as it could be high-cardinality. If this metric is needed, please add a new line to the `exporters.otelexporter.metric_aggregation_map` section of the configuration file.
 ```yaml


### PR DESCRIPTION
Add extra labels for the Topology Metric and Entity Metric of Redis' Requests.

## Entity Metric
| **Label** | **Example**                   | **Notes**                           |
| --- |-------------------------|--------------------------|
| `request_content` | GET | The command of the Redis request. |
| `response_content` | noerror | The value is either `error` or `noerror`. |

## Topology Metric

- **status_code**: `0` if there is no error; `1` otherwise.
