### PR TITLE
Add request/response payload of Redis to span data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 2. Records in this file are not identical to the title of their Pull Requests. A detailed description is necessary for understanding what changes are and why they are made.
 
 ## Unreleased 
+## Enhancements
+- Add request and response payload of `Redis` protocol message to `Span` data. ([#325](https://github.com/CloudDectective-Harmonycloud/kindling/pull/325))
 
 ## v0.4.1 - 2022-09-21
 ### Enhancements
 - When processing Redis' Requests, add additional labels to describe the key information of the message. Check [Metrics Document](https://github.com/CloudDectective-Harmonycloud/kindling/blob/main/docs/prometheus_metrics.md) for more details. ([#321](https://github.com/CloudDectective-Harmonycloud/kindling/pull/321))
 
 ### Bug fixes
-- Fix the bug when the kernel does not support some kprobe, the probe crashes.
+- Fix the bug when the kernel does not support some kprobe, the probe crashes. ([#320](https://github.com/CloudDectective-Harmonycloud/kindling/pull/320))
 
 ## v0.4.0 - 2022-09-19
 ### Enhancements

--- a/collector/pkg/component/analyzer/network/protocol/dubbo/dubbo_request.go
+++ b/collector/pkg/component/analyzer/network/protocol/dubbo/dubbo_request.go
@@ -19,7 +19,7 @@ func parseDubboRequest() protocol.ParsePkgFn {
 		}
 
 		message.AddStringAttribute(constlabels.ContentKey, contentKey)
-		message.AddStringAttribute(constlabels.DubboRequestPayload, getAsciiString(message.GetData(16, protocol.GetDubboPayLoadLength())))
+		message.AddStringAttribute(constlabels.RequestPayload, getAsciiString(message.GetData(16, protocol.GetDubboPayLoadLength())))
 		return true, true
 	}
 }

--- a/collector/pkg/component/analyzer/network/protocol/dubbo/dubbo_response.go
+++ b/collector/pkg/component/analyzer/network/protocol/dubbo/dubbo_response.go
@@ -23,7 +23,7 @@ func parseDubboResponse() protocol.ParsePkgFn {
 			message.AddBoolAttribute(constlabels.IsError, true)
 			message.AddIntAttribute(constlabels.ErrorType, int64(constlabels.ProtocolError))
 		}
-		message.AddStringAttribute(constlabels.DubboResponsePayload, getAsciiString(message.GetData(16, protocol.GetDubboPayLoadLength())))
+		message.AddStringAttribute(constlabels.ResponsePayload, getAsciiString(message.GetData(16, protocol.GetDubboPayLoadLength())))
 		return true, true
 	}
 }

--- a/collector/pkg/component/analyzer/network/protocol/http/http_parser_test.go
+++ b/collector/pkg/component/analyzer/network/protocol/http/http_parser_test.go
@@ -101,10 +101,10 @@ func TestParseHttpRequest_GetPayLoad(t *testing.T) {
 			message := protocol.NewRequestMessage([]byte(httpData))
 			NewHttpParser("").ParseRequest(message)
 
-			if !message.HasAttribute(constlabels.HttpRequestPayload) {
+			if !message.HasAttribute(constlabels.RequestPayload) {
 				t.Errorf("Fail to parse HttpRequest()")
 			}
-			if got := message.GetStringAttribute(constlabels.HttpRequestPayload); got != tt.want {
+			if got := message.GetStringAttribute(constlabels.RequestPayload); got != tt.want {
 				t.Errorf("GetHttpPayload() = %v, want %v", got, tt.want)
 			}
 		})
@@ -130,10 +130,10 @@ func TestParseHttpResponse_GetPayLoad(t *testing.T) {
 			message := protocol.NewResponseMessage([]byte(httpData), model.NewAttributeMap())
 			NewHttpParser("").ParseResponse(message)
 
-			if !message.HasAttribute(constlabels.HttpResponsePayload) {
+			if !message.HasAttribute(constlabels.ResponsePayload) {
 				t.Errorf("Fail to parse HttpResponse()")
 			}
-			if got := message.GetStringAttribute(constlabels.HttpResponsePayload); got != tt.want {
+			if got := message.GetStringAttribute(constlabels.ResponsePayload); got != tt.want {
 				t.Errorf("GetHttpPayload() = %v, want %v", got, tt.want)
 			}
 		})

--- a/collector/pkg/component/analyzer/network/protocol/http/http_request.go
+++ b/collector/pkg/component/analyzer/network/protocol/http/http_request.go
@@ -54,7 +54,7 @@ func parseHttpRequest(urlClusteringMethod urlclustering.ClusteringMethod) protoc
 
 		message.AddStringAttribute(constlabels.HttpMethod, string(method))
 		message.AddByteArrayUtf8Attribute(constlabels.HttpUrl, url)
-		message.AddByteArrayUtf8Attribute(constlabels.HttpRequestPayload, message.GetData(0, protocol.GetHttpPayLoadLength()))
+		message.AddByteArrayUtf8Attribute(constlabels.RequestPayload, message.GetData(0, protocol.GetHttpPayLoadLength()))
 
 		contentKey := urlClusteringMethod.Clustering(string(url))
 		if len(contentKey) == 0 {

--- a/collector/pkg/component/analyzer/network/protocol/http/http_response.go
+++ b/collector/pkg/component/analyzer/network/protocol/http/http_response.go
@@ -57,7 +57,7 @@ func parseHttpResponse() protocol.ParsePkgFn {
 		}
 
 		message.AddIntAttribute(constlabels.HttpStatusCode, statusCodeI)
-		message.AddByteArrayUtf8Attribute(constlabels.HttpResponsePayload, message.GetData(0, protocol.GetHttpPayLoadLength()))
+		message.AddByteArrayUtf8Attribute(constlabels.ResponsePayload, message.GetData(0, protocol.GetHttpPayLoadLength()))
 		if statusCodeI >= 400 {
 			message.AddBoolAttribute(constlabels.IsError, true)
 			message.AddIntAttribute(constlabels.ErrorType, int64(constlabels.ProtocolError))

--- a/collector/pkg/component/analyzer/network/protocol/protocol.go
+++ b/collector/pkg/component/analyzer/network/protocol/protocol.go
@@ -20,7 +20,7 @@ func GetPayLoadLength(protocol string) int {
 	if length, ok := payloadLength[protocol]; ok {
 		return length
 	}
-	return 80
+	return 200
 }
 
 func GetHttpPayLoadLength() int {

--- a/collector/pkg/component/analyzer/network/protocol/redis/redis_request.go
+++ b/collector/pkg/component/analyzer/network/protocol/redis/redis_request.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network/protocol"
+	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
 )
 
 /*
@@ -20,6 +21,7 @@ func fastfailRedisRequest() protocol.FastFailFn {
 
 func parseRedisRequest() protocol.ParsePkgFn {
 	return func(message *protocol.PayloadMessage) (bool, bool) {
+		message.AddByteArrayUtf8Attribute(constlabels.RequestPayload, message.GetData(0, protocol.GetPayLoadLength(protocol.REDIS)))
 		return true, false
 	}
 }

--- a/collector/pkg/component/analyzer/network/protocol/redis/redis_response.go
+++ b/collector/pkg/component/analyzer/network/protocol/redis/redis_response.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"github.com/Kindling-project/kindling/collector/pkg/component/analyzer/network/protocol"
+	"github.com/Kindling-project/kindling/collector/pkg/model/constlabels"
 )
 
 /*
@@ -24,6 +25,7 @@ func fastfailResponse() protocol.FastFailFn {
 
 func parseResponse() protocol.ParsePkgFn {
 	return func(message *protocol.PayloadMessage) (bool, bool) {
+		message.AddByteArrayUtf8Attribute(constlabels.ResponsePayload, message.GetData(0, protocol.GetPayLoadLength(protocol.REDIS)))
 		return true, false
 	}
 }

--- a/collector/pkg/component/analyzer/network/protocol/testdata/redis/server-trace-get.yml
+++ b/collector/pkg/component/analyzer/network/protocol/testdata/redis/server-trace-get.yml
@@ -46,3 +46,5 @@ trace:
         redis_command: "get"
         is_error: false
         error_type: 0
+        request_payload: "*2\r\n$3\r\nget\r\n$3\r\nkey\r\n"
+        response_payload: "$3\r\nabc\r\n"

--- a/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
+++ b/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
@@ -224,9 +224,9 @@ var spanProtocol = []extraLabelsParam{
 		{constlabels.SpanHttpStatusCode, constlabels.HttpStatusCode, Int64},
 		{constlabels.SpanHttpTraceId, constlabels.HttpApmTraceId, String},
 		{constlabels.SpanHttpTraceType, constlabels.HttpApmTraceType, String},
-		{constlabels.SpanHttpRequestHeaders, constlabels.HttpRequestPayload, String},
+		{constlabels.SpanHttpRequestHeaders, constlabels.RequestPayload, String},
 		{constlabels.SpanHttpRequestBody, constlabels.STR_EMPTY, StrEmpty},
-		{constlabels.SpanHttpResponseHeaders, constlabels.HttpResponsePayload, String},
+		{constlabels.SpanHttpResponseHeaders, constlabels.ResponsePayload, String},
 		{constlabels.SpanHttpResponseBody, constlabels.STR_EMPTY, StrEmpty},
 	}, extraLabelsKey{HTTP}},
 	{[]dictionary{
@@ -239,13 +239,15 @@ var spanProtocol = []extraLabelsParam{
 		{constlabels.SpanDnsRCode, constlabels.DnsRcode, FromInt64ToString},
 	}, extraLabelsKey{DNS}},
 	{[]dictionary{
-		{constlabels.SpanDubboRequestBody, constlabels.DubboRequestPayload, String},
-		{constlabels.SpanDubboResponseBody, constlabels.DubboResponsePayload, String},
+		{constlabels.SpanDubboRequestBody, constlabels.RequestPayload, String},
+		{constlabels.SpanDubboResponseBody, constlabels.ResponsePayload, String},
 		{constlabels.SpanDubboErrorCode, constlabels.DubboErrorCode, Int64},
 	}, extraLabelsKey{DUBBO}},
 	{[]dictionary{
 		{constlabels.SpanRedisCommand, constlabels.RedisCommand, String},
 		{constlabels.SpanRedisErrorMsg, constlabels.RedisErrMsg, String},
+		{constlabels.RequestPayload, constlabels.RequestPayload, String},
+		{constlabels.ResponsePayload, constlabels.ResponsePayload, String},
 	}, extraLabelsKey{REDIS}},
 	{
 		[]dictionary{}, extraLabelsKey{UNSUPPORTED},

--- a/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
+++ b/collector/pkg/component/consumer/exporter/tools/adapter/net_dict.go
@@ -246,8 +246,8 @@ var spanProtocol = []extraLabelsParam{
 	{[]dictionary{
 		{constlabels.SpanRedisCommand, constlabels.RedisCommand, String},
 		{constlabels.SpanRedisErrorMsg, constlabels.RedisErrMsg, String},
-		{constlabels.RequestPayload, constlabels.RequestPayload, String},
-		{constlabels.ResponsePayload, constlabels.ResponsePayload, String},
+		{constlabels.SpanRedisRequestPayload, constlabels.RequestPayload, String},
+		{constlabels.SpanRedisResponsePayload, constlabels.ResponsePayload, String},
 	}, extraLabelsKey{REDIS}},
 	{
 		[]dictionary{}, extraLabelsKey{UNSUPPORTED},

--- a/collector/pkg/model/constlabels/const.go
+++ b/collector/pkg/model/constlabels/const.go
@@ -103,8 +103,10 @@ const (
 	SpanDubboRequestBody  = "dubbo.request_body"
 	SpanDubboResponseBody = "dubbo.response_body"
 
-	SpanRedisCommand  = "redis.command"
-	SpanRedisErrorMsg = "redis.error_msg"
+	SpanRedisCommand         = "redis.command"
+	SpanRedisErrorMsg        = "redis.error_msg"
+	SpanRedisRequestPayload  = "redis.request_payload"
+	SpanRedisResponsePayload = "redis.request_payload"
 
 	NetWorkAnalyzeMetricGroup = "netAnalyzeMetrics"
 )

--- a/collector/pkg/model/constlabels/protocols.go
+++ b/collector/pkg/model/constlabels/protocols.go
@@ -1,15 +1,15 @@
 package constlabels
 
 const (
-	ContentKey = "content_key"
+	ContentKey      = "content_key"
+	RequestPayload  = "request_payload"
+	ResponsePayload = "response_payload"
 
-	HttpMethod          = "http_method"
-	HttpUrl             = "http_url"
-	HttpApmTraceType    = "trace_type"
-	HttpApmTraceId      = "trace_id"
-	HttpRequestPayload  = "request_payload"
-	HttpResponsePayload = "response_payload"
-	HttpStatusCode      = "http_status_code"
+	HttpMethod       = "http_method"
+	HttpUrl          = "http_url"
+	HttpApmTraceType = "trace_type"
+	HttpApmTraceId   = "trace_id"
+	HttpStatusCode   = "http_status_code"
 
 	DnsId     = "dns_id"
 	DnsDomain = "dns_domain"
@@ -27,10 +27,7 @@ const (
 	KafkaVersion       = "kafka_version"
 	KafkaCorrelationId = "kafka_id"
 	KafkaTopic         = "kafka_topic"
-	KafkaPartition     = "kafka_partition"
 	KafkaErrorCode     = "kafka_error_code"
 
-	DubboRequestPayload  = "request_payload"
-	DubboResponsePayload = "response_payload"
-	DubboErrorCode       = "dubbo_error_code"
+	DubboErrorCode = "dubbo_error_code"
 )


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add the fields `request_payload` and `response_payload` to the DataGroup in `networkanalyzer`.
- Add these fields to `span` in `net_dict`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now there is a field called "redis.command" which is enough for metrics. But for span data, users want to know which key the command is operating and what value it is. So the detailed information is added to the span data, which is named `payload.`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
go test -v network_analyzer_test.go network_analyzer.go config.go message_pair.go metric.go gauge_pool.go 

=== RUN   TestHttpProtocol
=== RUN   TestHttpProtocol/slowData
=== RUN   TestHttpProtocol/errorData
=== RUN   TestHttpProtocol/split
=== RUN   TestHttpProtocol/normal
--- PASS: TestHttpProtocol (0.01s)
    --- PASS: TestHttpProtocol/slowData (0.00s)
    --- PASS: TestHttpProtocol/errorData (0.00s)
    --- PASS: TestHttpProtocol/split (0.00s)
    --- PASS: TestHttpProtocol/normal (0.00s)
=== RUN   TestMySqlProtocol
=== RUN   TestMySqlProtocol/query-split
=== RUN   TestMySqlProtocol/query
--- PASS: TestMySqlProtocol (0.00s)
    --- PASS: TestMySqlProtocol/query-split (0.00s)
    --- PASS: TestMySqlProtocol/query (0.00s)
=== RUN   TestRedisProtocol
=== RUN   TestRedisProtocol/get
--- PASS: TestRedisProtocol (0.00s)
    --- PASS: TestRedisProtocol/get (0.00s)
=== RUN   TestDnsProtocol
=== RUN   TestDnsProtocol/multi
--- PASS: TestDnsProtocol (0.01s)
    --- PASS: TestDnsProtocol/multi (0.00s)
=== RUN   TestKafkaProtocol
=== RUN   TestKafkaProtocol/produce-split
=== RUN   TestKafkaProtocol/fetch-split
=== RUN   TestKafkaProtocol/fetch-one-topic-two-patitions
--- PASS: TestKafkaProtocol (0.01s)
    --- PASS: TestKafkaProtocol/produce-split (0.00s)
    --- PASS: TestKafkaProtocol/fetch-split (0.00s)
    --- PASS: TestKafkaProtocol/fetch-one-topic-two-patitions (0.00s)
=== RUN   TestDubboProtocol
=== RUN   TestDubboProtocol/shortData
--- PASS: TestDubboProtocol (0.00s)
    --- PASS: TestDubboProtocol/shortData (0.00s)
PASS
ok      command-line-arguments  0.071s
```