### PR TITLE
FIX slice outofbound when index less than 0 in GetBytes().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add request and response payload of `Redis` protocol message to `Span` data. ([#325](https://github.com/CloudDectective-Harmonycloud/kindling/pull/325))
 
 ### Bug fixes
-- Fix ReadBytes use negative number argument cuase slice outofbound. ([#327]https://github.com/CloudDectective-Harmonycloud/kindling/pull/327)
+- Fix the bug that if `ReadBytes` receives negative numbers as arguments, the program panics with the error of slice outofbound. ([#327](https://github.com/CloudDectective-Harmonycloud/kindling/pull/327))
 
 ## v0.4.1 - 2022-09-21
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 2. Records in this file are not identical to the title of their Pull Requests. A detailed description is necessary for understanding what changes are and why they are made.
 
 ## Unreleased 
+### Bug fixes
+- Fix ReadBytes use negative number argument cuase slice outofbound. ([#327]https://github.com/CloudDectective-Harmonycloud/kindling/pull/327)
 
 ## v0.4.1 - 2022-09-21
 ### Enhancements

--- a/collector/pkg/component/analyzer/network/protocol/dns/dns_request.go
+++ b/collector/pkg/component/analyzer/network/protocol/dns/dns_request.go
@@ -30,17 +30,17 @@ func fastfailDnsRequest() protocol.FastFailFn {
 func parseDnsRequest() protocol.ParsePkgFn {
 	return func(message *protocol.PayloadMessage) (bool, bool) {
 		offset := message.Offset
-		_, id := message.ReadUInt16(offset)
-		_, flags := message.ReadUInt16(offset + 2)
+		id, _ := message.ReadUInt16(offset)
+		flags, _ := message.ReadUInt16(offset + 2)
 
 		qr := (flags >> 15) & 0x1
 		opcode := (flags >> 11) & 0xf
 		rcode := flags & 0xf
 
-		_, numOfQuestions := message.ReadUInt16(offset + 4)
-		_, numOfAnswers := message.ReadUInt16(offset + 6)
-		_, numOfAuth := message.ReadUInt16(offset + 8)
-		_, numOfAddl := message.ReadUInt16(offset + 10)
+		numOfQuestions, _ := message.ReadUInt16(offset + 4)
+		numOfAnswers, _ := message.ReadUInt16(offset + 6)
+		numOfAuth, _ := message.ReadUInt16(offset + 8)
+		numOfAddl, _ := message.ReadUInt16(offset + 10)
 		numOfRR := numOfQuestions + numOfAnswers + numOfAuth + numOfAddl
 
 		/*

--- a/collector/pkg/component/analyzer/network/protocol/dns/dns_response.go
+++ b/collector/pkg/component/analyzer/network/protocol/dns/dns_response.go
@@ -39,17 +39,17 @@ Header
 func parseDnsResponse() protocol.ParsePkgFn {
 	return func(message *protocol.PayloadMessage) (bool, bool) {
 		offset := message.Offset
-		_, id := message.ReadUInt16(offset)
-		_, flags := message.ReadUInt16(offset + 2)
+		id, _ := message.ReadUInt16(offset)
+		flags, _ := message.ReadUInt16(offset + 2)
 
 		qr := (flags >> 15) & 0x1
 		opcode := (flags >> 11) & 0xf
 		rcode := flags & 0xf
 
-		_, numOfQuestions := message.ReadUInt16(offset + 4)
-		_, numOfAnswers := message.ReadUInt16(offset + 6)
-		_, numOfAuth := message.ReadUInt16(offset + 8)
-		_, numOfAddl := message.ReadUInt16(offset + 10)
+		numOfQuestions, _ := message.ReadUInt16(offset + 4)
+		numOfAnswers, _ := message.ReadUInt16(offset + 6)
+		numOfAuth, _ := message.ReadUInt16(offset + 8)
+		numOfAddl, _ := message.ReadUInt16(offset + 10)
 		numOfRR := numOfQuestions + numOfAnswers + numOfAuth + numOfAddl
 
 		/*
@@ -95,11 +95,11 @@ func parseDnsResponse() protocol.ParsePkgFn {
 
 func readIpV4Answer(message *protocol.PayloadMessage, answerCount uint16) string {
 	var (
-		complete bool
-		aType    uint16
-		length   uint16
-		ip       net.IP
-		ips      []string
+		aType  uint16
+		length uint16
+		ip     net.IP
+		ips    []string
+		err    error
 	)
 
 	ips = make([]string, 0)
@@ -114,21 +114,21 @@ func readIpV4Answer(message *protocol.PayloadMessage, answerCount uint16) string
 			string rdata
 		*/
 		offset += 2
-		complete, aType = message.ReadUInt16(offset)
-		if complete {
+		aType, err = message.ReadUInt16(offset)
+		if err != nil {
 			break
 		}
 
 		offset += 8
-		complete, length = message.ReadUInt16(offset)
-		if complete {
+		length, err = message.ReadUInt16(offset)
+		if err != nil {
 			break
 		}
 
 		offset += 2
 		if aType == TypeA {
-			offset, ip = message.ReadBytes(offset, int(length))
-			if ip == nil {
+			offset, ip, err = message.ReadBytes(offset, int(length))
+			if err != nil {
 				break
 			}
 			ips = append(ips, ip.String())

--- a/collector/pkg/component/analyzer/network/protocol/protocol_parser.go
+++ b/collector/pkg/component/analyzer/network/protocol/protocol_parser.go
@@ -144,7 +144,7 @@ func (message *PayloadMessage) ReadBytes(offset int, length int) (toOffset int, 
 		return EOF, nil, ErrArgumentInvalid
 	}
 	maxLength := offset + length
-	if maxLength >= len(message.Data) {
+	if maxLength > len(message.Data) {
 		return EOF, nil, ErrMessageShort
 	}
 	return maxLength, message.Data[offset:maxLength], nil

--- a/collector/pkg/component/analyzer/network/protocol/protocol_parser_test.go
+++ b/collector/pkg/component/analyzer/network/protocol/protocol_parser_test.go
@@ -6,6 +6,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestReadBytes(t *testing.T) {
+	// ff 0 4 t e s t
+	data := []byte{0xff, 0x00, 0x04, 0x74, 0x65, 0x73, 0x74}
+	message := NewRequestMessage(data)
+
+	tests := []struct {
+		name   string
+		offset int
+		length int
+		expect []byte
+		err    error
+	}{
+		{"Invalid Index", -1, 1, nil, ErrArgumentInvalid},
+		{"Invalid Index", 1, -1, nil, ErrArgumentInvalid},
+		{"Positive Integer", 1, 4, []byte{0x00, 0x04, 0x74, 0x65}, nil},
+		{"Large Integer", 2, 1140, nil, ErrMessageShort},
+		{"Overflow Index", 10, 1, nil, ErrMessageShort},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, realValue, err := message.ReadBytes(test.offset, test.length)
+			if err != nil {
+				assert.Equal(t, test.err, err)
+				return
+			}
+			assert.Equal(t, test.expect, realValue)
+		})
+	}
+}
+
 func TestReadInt16(t *testing.T) {
 	// ff 0 4 t e s t
 	data := []byte{0xff, 0x00, 0x04, 0x74, 0x65, 0x73, 0x74}
@@ -17,7 +48,7 @@ func TestReadInt16(t *testing.T) {
 		expect int16
 		err    error
 	}{
-		{"Invalid Index", -1, -1, ErrMessageInvalid},
+		{"Invalid Index", -1, -1, ErrArgumentInvalid},
 		{"Negative Number", 0, -256, nil},
 		{"Positive Integer", 1, 4, nil},
 		{"Large Integer", 2, 1140, nil},
@@ -47,7 +78,7 @@ func TestReadInt32(t *testing.T) {
 		expect int32
 		err    error
 	}{
-		{"Invalid Index", -1, -1, ErrMessageInvalid},
+		{"Invalid Index", -1, -1, ErrArgumentInvalid},
 		{"Negative Number", 0, -16777216, nil},
 		{"Positive Integer", 1, 4, nil},
 		{"Large Integer", 2, 1140, nil},
@@ -77,7 +108,7 @@ func TestReadNullableString(t *testing.T) {
 		expect string
 		err    error
 	}{
-		{"Invalid Index", -1, "", ErrMessageInvalid},
+		{"Invalid Index", -1, "", ErrArgumentInvalid},
 		{"Invalid Length", 0, "", ErrMessageInvalid},
 		{"Normal String", 1, "test", nil},
 		{"Trim String", 2, "est", nil},

--- a/collector/pkg/component/analyzer/network/protocol/protocol_parser_test.go
+++ b/collector/pkg/component/analyzer/network/protocol/protocol_parser_test.go
@@ -21,6 +21,7 @@ func TestReadBytes(t *testing.T) {
 		{"Invalid Index", -1, 1, nil, ErrArgumentInvalid},
 		{"Invalid Index", 1, -1, nil, ErrArgumentInvalid},
 		{"Positive Integer", 1, 4, []byte{0x00, 0x04, 0x74, 0x65}, nil},
+		{"All Datas", 0, 7, []byte{0xff, 0x00, 0x04, 0x74, 0x65, 0x73, 0x74}, nil},
 		{"Large Integer", 2, 1140, nil, ErrMessageShort},
 		{"Overflow Index", 10, 1, nil, ErrMessageShort},
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
ReadBytes(offset int, length int) API doesn't check strictly. When offset is a negative number, the array operation will out of bound.

## Description
Add error return.
When argument is less than 0, the result will return invalid argument error.

## Related Issue
[Issue 326](https://github.com/CloudDectective-Harmonycloud/kindling/issues/326)

## Motivation and Context
Fix array out of bound in ReadBytes() with negative number.

## How Has This Been Tested?
test TestReadBytes() in protocol_parser_test.go