### PR TITLE
Improve the shell script for building the go executable

### DIFF
--- a/collector/collector-version-build.sh
+++ b/collector/collector-version-build.sh
@@ -1,5 +1,16 @@
 GitCommit=$(git rev-parse --short HEAD || echo unsupported)
-echo "Git commit:" $GitCommit
-go build -o docker/kindling-collector -ldflags="-X 'github.com/Kindling-project/kindling/collector/version.CodeVersion=$GitCommit'" ./cmd/kindling-collector/
+echo "Git commit:" "$GitCommit"
+
+BINARY_PATH=docker/kindling-collector
+echo "The output path of the go executable file is" "$(pwd)/$BINARY_PATH"
+
+if [ -f $BINARY_PATH ]; then
+  echo "There is an old executable file. Clean it first..."
+  rm -f $BINARY_PATH
+  echo "Clean done."
+fi
+
+echo "Start to build the executable..."
+go build -v -o $BINARY_PATH -ldflags="-X 'github.com/Kindling-project/kindling/collector/version.CodeVersion=$GitCommit'" ./cmd/kindling-collector/
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
1. Clean the go executable, if existing, before building it again to prevent the `deploy/scripts/build.sh` from always building an image using the old executable when `go build` fails.
2. Add logs when building the go executable to allow users to know what is happening in the building procedure.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an open issue describing it with details -->
<!--- Please link to the issue here: -->
#329 
